### PR TITLE
Clarify how to preview locally, view a notebook in fullscreen, and link config docs

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -1,7 +1,7 @@
 Configuration
 =============
 
-You can provide custom configuration to your JupyterLite deployment.
+You can provide `custom configuration <https://jupyterlite.readthedocs.io/en/latest/configuring.html>`_ to your JupyterLite deployment.
 
 For example, if you want to have bqplot working in this deployment, you need to install the bqplot federated extension
 and you can serve the bqplot wheel to ``piplite``, this is done by telling your ``conf.py`` where to look for the jupyterlite config:

--- a/docs/full.rst
+++ b/docs/full.rst
@@ -3,7 +3,7 @@ Fullscreen access
 
 You can access the JupyterLite deployment that ``jupyterlite-sphinx`` made for you, in fullscreen, following the ``./lite/lab`` and ``./lite/retro`` relative urls:
 
+- `JupyterLab <./lite/lab/index.html>`_
+- `Retrolab <./lite/retro/index.html>`_
 
-`JupyterLab <./lite/lab/index.html>`_
-
-`Retrolab <./lite/retro/index.html>`_
+If you want to open a specific notebook in fullscreen  JupyterLab/Retrolab you can use the ``path`` URL parameter, e.g. ``./lite/lab/?path=my_noteboook.ipynb``.

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -16,3 +16,5 @@ then you need to add the ``jupyterlite-sphinx`` extension to your ``conf.py`` fi
         # And other sphinx extensions
         # ...
     ]
+
+JupyterLite should automatically show up in your built online documentation. To preview it locally, you can navigate to the build directory (e.g. ``_build/html``) and use ``python -m http.server`` to serve the site.


### PR DESCRIPTION
I found these things out after some looking around and I think it would be great to mention them in the docs.

Ref:
- https://github.com/jupyterlite/jupyterlite-sphinx/issues/44
- https://github.com/jupyterlite/jupyterlite-sphinx/issues/37
