### PR TITLE
Allow whitespace in filenames

### DIFF
--- a/src/jupyterlite_sphinx.py
+++ b/src/jupyterlite_sphinx.py
@@ -168,6 +168,7 @@ class _LiteDirective(SphinxDirective):
 
     has_content = False
     optional_arguments = 1
+    final_argument_whitespace = True
     option_spec = {
         "width": directives.unchanged,
         "height": directives.unchanged,


### PR DESCRIPTION
Without this, a space in a filename makes it into two separate arguments.

This aligns with the literalinclude directive, which also takes filenames:

https://github.com/sphinx-doc/sphinx/blob/7bdc11e87c7d86dcc2a087eccb7a7c129a473415/sphinx/directives/code.py#L374