### PR TITLE
Run jupyter lite with subprocess.run to not suppress stdout

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     python_requires='>=3.7',
     install_requires=[
         'docutils',
-        'jupyterlite',
+        'jupyterlite[piplite]',
         'sphinx>=4,<5',
         'jupyter_server',
         'jupyterlab_server',

--- a/src/jupyterlite_sphinx.py
+++ b/src/jupyterlite_sphinx.py
@@ -282,7 +282,7 @@ def jupyterlite_build(app: Sphinx, error):
                     "--output-dir",
                     os.path.join(app.outdir, JUPYTERLITE_DIR),
                 ],
-                check=True
+                check=True,
             )
 
         print("[jupyterlite-sphinx] JupyterLite build done")

--- a/src/jupyterlite_sphinx.py
+++ b/src/jupyterlite_sphinx.py
@@ -268,7 +268,7 @@ def jupyterlite_build(app: Sphinx, error):
             config = ["--config", app.env.config.jupyterlite_config]
 
         with tempfile.TemporaryDirectory() as tmp_dir:
-            subprocess.check_output(
+            subprocess.run(
                 [
                     "jupyter",
                     "lite",
@@ -281,7 +281,8 @@ def jupyterlite_build(app: Sphinx, error):
                     os.path.join(app.srcdir, CONTENT_DIR),
                     "--output-dir",
                     os.path.join(app.outdir, JUPYTERLITE_DIR),
-                ]
+                ],
+                check=True
             )
 
         print("[jupyterlite-sphinx] JupyterLite build done")


### PR DESCRIPTION
check_output redirects stdout, so we don't see it when we do sphinx-build. We instead switch to using subprocess.run so that we can see the stdout output.

Suppressing stdout was causing errors in jupyter lite to not be displayed, which was very confusing.

A separate issue is that jupyter lite is not returning a nonzero exit code when there is an error. But that is a problem to solve in jupyter lite. Once it is solved, having the check=True means that the sphinx build will also raise an error.