### PR TITLE
Update Pypi description to be the same as the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A Sphinx extension that provides utilities for embedding [JupyterLite](https://j
 
 ## Docs
 
-https://jupyterlite-sphinx.readthedocs.io/en/latest
+https://jupyterlite-sphinx.readthedocs.io
 
 ## Example
 

--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
 # JupyterLite Sphinx
 
-A Sphinx extension that provides utilities for embedding JupyterLite in your docs
+A Sphinx extension that provides utilities for embedding [JupyterLite](https://jupyterlite.readthedocs.io) in your documentation.
 
-### Docs
+## Docs
 
 https://jupyterlite-sphinx.readthedocs.io/en/latest
 
-### Example
+## Example
 
-A practical example is the ipycanvas documentation: https://ipycanvas.readthedocs.io/en/master
+Practical examples are in the [ipycanvas](https://ipycanvas.readthedocs.io) and [ipyleaflet](https://ipyleaflet.readthedocs.io) documentation.
 
-### Installation:
+## Installation:
 
 ```bash
 pip install jupyterlite-sphinx

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,15 @@
 from setuptools import setup
 
 
+from pathlib import Path
+this_directory = Path(__file__).parent
+long_description = (this_directory / "README.md").read_text()
+
 setup(
     name='jupyterlite-sphinx',
     version='0.4.9',
+    long_description=long_description,
+    long_description_content_type='text/markdown',
     package_dir={'': 'src'},
     py_modules=['jupyterlite_sphinx'],
     python_requires='>=3.7',


### PR DESCRIPTION
Right now pypi says there is no description, so we just use the standard way to read in the readme file.