### PR TITLE
Update docs to use the new options

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -10,7 +10,7 @@ You can embed custom content (notebooks and data files) in your JupyterLite buil
 
 .. code-block:: python
 
-    jupyterlite_contents = ["./path/to/my/notebooks/", "my_other_notebook.ipynb"]
+    jupyter_lite_contents = ["./path/to/my/notebooks/", "my_other_notebook.ipynb"]
 
 JupyterLite dir
 ---------------
@@ -20,7 +20,7 @@ By default, jupyterlite-sphinx runs the ``jupyter lite build`` command in a temp
 .. code-block:: python
 
     # Build in the current directory
-    jupyterlite_dir = "."
+    jupyter_lite_dir = "."
 
 This allows for jupyterlite to automatically pick-up some paths https://jupyterlite.readthedocs.io/en/latest/reference/cli.html#the-lite-dir
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -34,9 +34,9 @@ and you can serve the bqplot wheel to ``piplite``, this is done by telling your 
 
 .. code-block:: python
 
-    jupyterlite_config = "jupyterlite_config.json"
+    jupyter_lite_config = "jupyter_lite_config.json"
 
-The ``jupyterlite_config.json`` containing the following:
+The ``jupyter_lite_config.json`` containing the following:
 
 .. code-block:: json
 


### PR DESCRIPTION
Update the docs:

- `jupyterlite_contents` -> `jupyter_lite_contents`
- `jupyterlite_dir` -> `jupyter_lite_dir`
- `jupyterlite_config` -> `jupyter_lite_config`

Based on what is parsed in the source:

https://github.com/jupyterlite/jupyterlite-sphinx/blob/495fa16d53c291f794d340ff9667c7b2134caa39/src/jupyterlite_sphinx.py#L269-L271

https://github.com/jupyterlite/jupyterlite-sphinx/blob/495fa16d53c291f794d340ff9667c7b2134caa39/src/jupyterlite_sphinx.py#L342-L344
