### PR TITLE
Make .ipynb source binding an opt-out

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -59,3 +59,15 @@ Then you should be able to show Notebooks working with bqplot!
     .. retrolite:: bqplot.ipynb
 
 .. retrolite:: bqplot.ipynb
+
+Disable the ``.ipynb`` docs source binding
+------------------------------------------
+
+By default, jupyterlite-sphinx binds the ``.ipynb`` source suffix so that it renders Notebooks included in the doctree with JupyterLite.
+This is known to bring warnings with plugins like sphinx-gallery, or to conflict with nbsphinx.
+
+You can disable this behavior by setting the following config:
+
+.. code-block:: python
+
+    jupyterlite_bind_ipynb_suffix = False

--- a/src/jupyterlite_sphinx.py
+++ b/src/jupyterlite_sphinx.py
@@ -253,7 +253,8 @@ def inited(app: Sphinx, config):
     os.makedirs(os.path.join(app.srcdir, CONTENT_DIR), exist_ok=True)
 
     if (
-        ".ipynb" not in config.source_suffix
+        config.jupyterlite_bind_ipynb_suffix
+        and ".ipynb" not in config.source_suffix
         and ".ipynb" not in app.registry.source_suffix
     ):
         app.add_source_suffix(".ipynb", "jupyterlite_notebook")
@@ -334,6 +335,7 @@ def setup(app):
     app.add_config_value("jupyterlite_config", None, rebuild="html")
     app.add_config_value("jupyterlite_dir", None, rebuild="html")
     app.add_config_value("jupyterlite_contents", None, rebuild="html")
+    app.add_config_value("jupyterlite_bind_ipynb_suffix", True, rebuild="html")
 
     # Initialize RetroLite and JupyterLite directives
     app.add_node(


### PR DESCRIPTION
Should fix https://github.com/jupyterlite/jupyterlite-sphinx/issues/65 

This helps resolving warnings in https://github.com/matplotlib/matplotlib/pull/22634