### PR TITLE
Make the jupyterlite_contents glob recursive.

### DIFF
--- a/jupyterlite_sphinx/jupyterlite_sphinx.py
+++ b/jupyterlite_sphinx/jupyterlite_sphinx.py
@@ -300,7 +300,7 @@ def jupyterlite_build(app: Sphinx, error):
             jupyterlite_contents = [
                 match
                 for pattern in jupyterlite_contents
-                for match in glob.glob(pattern)
+                for match in glob.glob(pattern, recursive=True)
             ]
         jupyterlite_dir = app.env.config.jupyterlite_dir
 


### PR DESCRIPTION
Since we have shifted to using globs for the contents, we might as well enable the strictly more powerful ** recursive syntax. See https://docs.python.org/3/library/glob.html#glob.glob

"If recursive is true, the pattern “**” will match any files and zero or more directories, subdirectories and symbolic links to directories. If the pattern is followed by an os.sep or os.altsep then files will not match."