### PR TITLE
Restore jupyterlite_contents being optionally a string

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -12,6 +12,8 @@ You can embed custom content (notebooks and data files) in your JupyterLite buil
 
     jupyterlite_contents = ["./path/to/my/notebooks/", "my_other_notebook.ipynb"]
 
+``jupyterlite_contents`` can be a string or a list of strings. Each string is expanded using the Python ``glob.glob`` function with its recursive option. See the `glob documentation <https://docs.python.org/3/library/glob.html#glob.glob>`_ and the `wildcard pattern documentation <https://docs.python.org/3/library/fnmatch.html#fnmatch.fnmatch>`_ for more details.
+
 JupyterLite dir
 ---------------
 

--- a/jupyterlite_sphinx/jupyterlite_sphinx.py
+++ b/jupyterlite_sphinx/jupyterlite_sphinx.py
@@ -296,26 +296,27 @@ def jupyterlite_build(app: Sphinx, error):
         print("[jupyterlite-sphinx] Running JupyterLite build")
         jupyterlite_config = app.env.config.jupyterlite_config
         jupyterlite_contents = app.env.config.jupyterlite_contents
-        if jupyterlite_contents is not None:
-            jupyterlite_contents = [
-                match
-                for pattern in jupyterlite_contents
-                for match in glob.glob(pattern, recursive=True)
-            ]
         jupyterlite_dir = app.env.config.jupyterlite_dir
 
         config = []
         if jupyterlite_config:
             config = ["--config", jupyterlite_config]
 
-        contents = []
-        if jupyterlite_contents:
-            if isinstance(jupyterlite_contents, str):
-                contents.extend(["--contents", jupyterlite_contents])
+        if jupyterlite_contents is None:
+            jupyterlite_contents = []
+        elif isinstance(jupyterlite_contents, str):
+            jupyterlite_contents = [jupyterlite_contents]
 
-            if isinstance(jupyterlite_contents, (tuple, list)):
-                for content in jupyterlite_contents:
-                    contents.extend(["--contents", content])
+        # Expand globs in the contents strings
+        jupyterlite_contents = [
+            match
+            for pattern in jupyterlite_contents
+            for match in glob.glob(pattern, recursive=True)
+        ]
+
+        contents = []
+        for content in jupyterlite_contents:
+            contents.extend(["--contents", content])
 
         command = [
             "jupyter",


### PR DESCRIPTION
Restore jupyterlite_contents being a string (which was lost when we moved to using globs). Also, add some documentation about values for jupyterlite_contents.