### PR TITLE
DOC fix broken link to custom Jupyterlite configuration

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -29,7 +29,8 @@ This allows for jupyterlite to automatically pick-up some paths https://jupyterl
 JupyterLite config
 ------------------
 
-You can provide `custom configuration <https://jupyterlite.readthedocs.io/en/latest/configuring.html>`_ to your JupyterLite deployment.
+You can provide `custom configuration <https://jupyterlite.readthedocs.io/en/latest/howto/index.html#configuring-a-jupyterlite-deployment>`_
+to your JupyterLite deployment.
 
 For example, if you want to have bqplot working in this deployment, you need to install the bqplot federated extension
 and you can serve the bqplot wheel to ``piplite``, this is done by telling your ``conf.py`` where to look for the jupyterlite config:


### PR DESCRIPTION
The link is currently broken. Not sure whether there is a more appropriate link that the one I used and ends up in the middle of the HowTo guide.

To get an idea about the original content the link was pointing to, see:
https://github.com/jupyterlite/jupyterlite/blob/dc395c42d610a0bc6f96bb715a3f130e2ef7c43a/docs/configuring.md
