### PR TITLE
Update the `piplite_urls` configuration

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -48,7 +48,9 @@ The ``jupyterlite_config.json`` containing the following:
             "federated_extensions": [
                 "https://conda.anaconda.org/conda-forge/noarch/bqplot-0.12.33-pyhd8ed1ab_0.tar.bz2",
             ],
-            "ignore_sys_prefix": true,
+            "ignore_sys_prefix": true
+        }
+        "PipliteAddon": {
             "piplite_urls": [
                 "https://files.pythonhosted.org/packages/py2.py3/b/bqplot/bqplot-0.12.33-py2.py3-none-any.whl",
             ]

--- a/docs/jupyter_lite_config.json
+++ b/docs/jupyter_lite_config.json
@@ -18,7 +18,9 @@
         "https://conda.anaconda.org/conda-forge/noarch/theme-darcula-3.1.1-pyh3684270_0.tar.bz2",
         "https://github.com/jupyterlite/p5-kernel/releases/download/v0.1.0a12/jupyterlite_p5_kernel-0.1.0a12-py3-none-any.whl"
       ],
-      "ignore_sys_prefix": true,
+      "ignore_sys_prefix": true
+    },
+    "PipliteAddon": {
       "piplite_urls": [
         "https://files.pythonhosted.org/packages/py2.py3/a/asttokens/asttokens-2.0.5-py2.py3-none-any.whl",
         "https://files.pythonhosted.org/packages/py2.py3/b/backcall/backcall-0.2.0-py2.py3-none-any.whl",


### PR DESCRIPTION
The latest `0.1.0b17` release changed how `piplite_urls` should be configured: https://github.com/jupyterlite/jupyterlite/releases/tag/v0.1.0b17