### PR TITLE
build: build up to sphinx 6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     install_requires=[
         'docutils',
         'jupyterlite[piplite]',
-        'sphinx>=4,<5',
+        'sphinx>=4,<7',
         'jupyter_server',
         'jupyterlab_server',
     ],


### PR DESCRIPTION
Just to check how the build and CI run with the latest version of `Sphinx`. I think at least `Sphinx 5` is required but let's be crazy and see what happens with `Sphinx 6`.

Fix #83 