### PR TITLE
Depend on `jupyterlite-core`

### DIFF
--- a/dev-environment.yml
+++ b/dev-environment.yml
@@ -11,5 +11,4 @@ dependencies:
     - black
     - pip:
         - jupyterlite-core==0.1.0b19
-        - jupyterlite-pyodide-kernel==0.0.5
 

--- a/dev-environment.yml
+++ b/dev-environment.yml
@@ -10,4 +10,6 @@ dependencies:
     - sphinx
     - black
     - pip:
-        - jupyterlite-core @ https://jupyterlite--994.org.readthedocs.build/en/994/_static/jupyterlite_core-0.1.0b18-py3-none-any.whl
+        - jupyterlite-core==0.1.0b19
+        - jupyterlite-pyodide-kernel==0.0.5
+

--- a/dev-environment.yml
+++ b/dev-environment.yml
@@ -10,4 +10,4 @@ dependencies:
     - sphinx
     - black
     - pip:
-        - jupyterlite
+        - jupyterlite-core @ https://jupyterlite--994.org.readthedocs.build/en/994/_static/jupyterlite_core-0.1.0b18-py3-none-any.whl

--- a/docs/jupyter_lite_config.json
+++ b/docs/jupyter_lite_config.json
@@ -16,7 +16,8 @@
         "https://conda.anaconda.org/conda-forge/noarch/jupyterlab_widgets-1.1.1-pyhd8ed1ab_0.tar.bz2",
         "https://conda.anaconda.org/conda-forge/noarch/plotly-5.6.0-pyhd8ed1ab_0.tar.bz2",
         "https://conda.anaconda.org/conda-forge/noarch/theme-darcula-3.1.1-pyh3684270_0.tar.bz2",
-        "https://github.com/jupyterlite/p5-kernel/releases/download/v0.1.0a12/jupyterlite_p5_kernel-0.1.0a12-py3-none-any.whl"
+        "https://github.com/jupyterlite/p5-kernel/releases/download/v0.1.0a12/jupyterlite_p5_kernel-0.1.0a12-py3-none-any.whl",
+        "https://github.com/jupyterlite/pyodide-kernel/releases/download/v0.0.5/jupyterlite_pyodide_kernel-0.0.5-py3-none-any.whl"
       ],
       "ignore_sys_prefix": true
     },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,9 @@ dependencies = [
     "sphinx>=4",
 ]
 
+[tool.hatch.metadata]
+allow-direct-references = true
+
 [tool.hatch.version]
 path = "jupyterlite_sphinx/__init__.py"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     "docutils",
     "jupyter_server",
     "jupyterlab_server",
-    "jupyterlite-core[piplite] >=0.1.0b19",
+    "jupyterlite-core >=0.1.0b19",
     "sphinx>=4",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     "docutils",
     "jupyter_server",
     "jupyterlab_server",
-    "jupyterlite-core[piplite] @ https://jupyterlite--994.org.readthedocs.build/en/994/_static/jupyterlite_core-0.1.0b18-py3-none-any.whl",
+    "jupyterlite-core[piplite] >=0.1.0b19",
     "sphinx>=4",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     "docutils",
     "jupyter_server",
     "jupyterlab_server",
-    "jupyterlite[piplite]",
+    "jupyterlite-core[piplite] @ https://jupyterlite--994.org.readthedocs.build/en/994/_static/jupyterlite_core-0.1.0b18-py3-none-any.whl",
     "sphinx>=4",
 ]
 


### PR DESCRIPTION
Similar to https://github.com/jupyterlite/xeus-python-kernel/pull/114

The core functionality of the `jupyterlite` package is being extracted to a new `jupyterlite-core` package in https://github.com/jupyterlite/jupyterlite/pull/994.

This will allow site deployers to make slimmer deployments without having to bring the Pyodide kernel by default.

### TODO

- [x] Try depending on `jupyterlite-core` built from https://github.com/jupyterlite/jupyterlite/pull/994
- [x] Update to the real `jupyterlite-core` dependency when a release is available (likely after https://github.com/jupyterlite/jupyterlite/pull/994 is merged)
- [ ] Update the docs environment
- [x] Re-add a Python kernel to the docs environment