### PR TITLE
Update to `jupyterlite-core==0.1.0`, require Python 3.8

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,18 @@
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: '3.11'
+    nodejs: '18'
+python:
+  install:
+    - method: pip
+      path: .
+      extra_requirements:
+        - docs
+
+sphinx:
+  builder: html
+  configuration: docs/conf.py
+  fail_on_warning: true

--- a/dev-environment.yml
+++ b/dev-environment.yml
@@ -5,9 +5,8 @@ dependencies:
     - pip
     - jupyter_server
     - jupyterlab_server
+    - jupyterlite-core >=0.1.0,<0.2
     - pydata-sphinx-theme
     - docutils
     - sphinx
     - black
-    - pip:
-        - jupyterlite-core==0.1.0

--- a/dev-environment.yml
+++ b/dev-environment.yml
@@ -3,6 +3,7 @@ channels:
     - conda-forge
 dependencies:
     - pip
+    - python >=3.10
     - jupyter_server
     - jupyterlab_server
     - pydata-sphinx-theme

--- a/dev-environment.yml
+++ b/dev-environment.yml
@@ -10,5 +10,4 @@ dependencies:
     - sphinx
     - black
     - pip:
-        - jupyterlite-core==0.1.0b19
-
+        - jupyterlite-core==0.1.0

--- a/dev-environment.yml
+++ b/dev-environment.yml
@@ -3,7 +3,6 @@ channels:
     - conda-forge
 dependencies:
     - pip
-    - python >=3.10
     - jupyter_server
     - jupyterlab_server
     - pydata-sphinx-theme

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,0 @@
-# Tests documentation for jupyterlite-sphinx
-
-```bash
-sphinx-build . build -vvv
-```

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -37,3 +37,5 @@ html_theme_options = {
 
 # Copy the markdown file here
 shutil.copy(ROOT / "CHANGELOG.md", HERE / "changelog.md")
+
+suppress_warnings = ["myst.xref_missing"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 description = "Sphinx extension for deploying JupyterLite"
 readme = "README.md"
 license = { file = "LICENSE" }
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 authors = [
     { name = "JupyterLite Contributors" },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,12 @@ dependencies = [
     "sphinx>=4",
 ]
 
+[project.optional-dependencies]
+docs = [
+    "myst_parser",
+    "pydata-sphinx-theme",
+]
+
 [tool.hatch.metadata]
 allow-direct-references = true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,9 +26,6 @@ docs = [
     "pydata-sphinx-theme",
 ]
 
-[tool.hatch.metadata]
-allow-direct-references = true
-
 [tool.hatch.version]
 path = "jupyterlite_sphinx/__init__.py"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     "docutils",
     "jupyter_server",
     "jupyterlab_server",
-    "jupyterlite-core >=0.1.0b19",
+    "jupyterlite-core >=0.1.0",
     "sphinx>=4",
 ]
 


### PR DESCRIPTION
Couple of maintenance tasks:

- Update to the latest release: https://github.com/jupyterlite/jupyterlite/releases/tag/v0.1.0
- Require Python 3.8
- Streamline the ReadTheDocs preview