### PR TITLE
Prevent caching of notebook content

### DIFF
--- a/docs/lite/jupyter-lite.json
+++ b/docs/lite/jupyter-lite.json
@@ -1,0 +1,7 @@
+{
+    "jupyter-config-data": {
+      "enableMemoryStorage": true,
+      "settingsStorageDrivers": ["memoryStorageDriver"],
+      "contentsStorageDrivers": ["memoryStorageDriver"]
+    }
+  }


### PR DESCRIPTION
Related issue https://github.com/jupyterlite/jupyterlite-sphinx/issues/101.

I added a config file that will hopefully disable the caching of notebook content in the docs at https://jupyterlite-sphinx.readthedocs.io/en/latest/directives/retrolite.html, thanks to the suggestion from 
@agoose77 in https://github.com/jupyterlite/jupyterlite-sphinx/issues/101#issuecomment-1551228918