### PR TITLE
Transfer search parameters from page URL to jupyterlite

### DIFF
--- a/docs/directives/jupyterlite.md
+++ b/docs/directives/jupyterlite.md
@@ -36,7 +36,7 @@ You can also pass a Notebook file to open automatically:
    :prompt_color: #00aa42
 ```
 
-
 The directive `search_params` allows to transfer some search parameters from the documentation URL to the Jupyterlite URL.\
 Jupyterlite is than able to these parameters from its own URL.\
 For example `:search_params: param1, param2` will transfer the parameters *param1* and *param2*.
+Transferring all the parameters: `:search_params: =all`

--- a/docs/directives/jupyterlite.md
+++ b/docs/directives/jupyterlite.md
@@ -35,3 +35,8 @@ You can also pass a Notebook file to open automatically:
    :prompt: Try JupyterLite!
    :prompt_color: #00aa42
 ```
+
+
+The directive `search_params` allows to transfer some search parameters from the documentation URL to the Jupyterlite URL.\
+Jupyterlite is than able to these parameters from its own URL.\
+For example `:search_params: param1, param2` will transfer the parameters *param1* and *param2*.

--- a/docs/directives/jupyterlite.md
+++ b/docs/directives/jupyterlite.md
@@ -37,6 +37,6 @@ You can also pass a Notebook file to open automatically:
 ```
 
 The directive `search_params` allows to transfer some search parameters from the documentation URL to the Jupyterlite URL.\
-Jupyterlite is than able to these parameters from its own URL.\
-For example `:search_params: param1, param2` will transfer the parameters *param1* and *param2*.
-Transferring all the parameters: `:search_params: =all`
+Jupyterlite will then be able to fetch these parameters from its own URL.\
+For example `:search_params: ["param1", "param2"]` will transfer the parameters *param1* and *param2*.
+Use a boolean value to transfer all or none of the parameters (default to none): `:search_params: True`

--- a/jupyterlite_sphinx/jupyterlite_sphinx.js
+++ b/jupyterlite_sphinx/jupyterlite_sphinx.js
@@ -18,9 +18,14 @@ window.jupyterliteConcatSearchParams = (iframeSrc, params) => {
 
   let pageParams = new URLSearchParams(window.location.search);
 
-  if (params.includes('=all')) {
+  if (params === true) {
     params = Array.from(pageParams.keys());
+  } else if (params === false) {
+    params = [];
+  } else if (!Array.isArray(params)) {
+    console.error('The search parameters are not an array');
   }
+
   params.forEach(param => {
     value = pageParams.get(param);
     if (value !== null) {

--- a/jupyterlite_sphinx/jupyterlite_sphinx.js
+++ b/jupyterlite_sphinx/jupyterlite_sphinx.js
@@ -18,6 +18,9 @@ window.jupyterliteConcatSearchParams = (iframeSrc, params) => {
 
   let pageParams = new URLSearchParams(window.location.search);
 
+  if (params.includes('=all')) {
+    params = Array.from(pageParams.keys());
+  }
   params.forEach(param => {
     value = pageParams.get(param);
     if (value !== null) {

--- a/jupyterlite_sphinx/jupyterlite_sphinx.js
+++ b/jupyterlite_sphinx/jupyterlite_sphinx.js
@@ -11,3 +11,19 @@ window.jupyterliteShowIframe = (tryItButtonId, iframeSrc) => {
   tryItButton.classList.remove('jupyterlite_sphinx_try_it_button_unclicked');
   tryItButton.classList.add('jupyterlite_sphinx_try_it_button_clicked');
 }
+
+window.jupyterliteConcatSearchParams = (iframeSrc, params) => {
+  const baseURL = window.location.origin;
+  const iframeUrl = new URL(iframeSrc, baseURL);
+
+  let pageParams = new URLSearchParams(window.location.search);
+
+  params.forEach(param => {
+    value = pageParams.get(param);
+    if (value !== null) {
+      iframeUrl.searchParams.append(param, value);
+    }
+  });
+
+  return iframeUrl.toString().replace(baseURL, '');
+}

--- a/jupyterlite_sphinx/jupyterlite_sphinx.py
+++ b/jupyterlite_sphinx/jupyterlite_sphinx.py
@@ -510,7 +510,7 @@ def search_params_parser(search_params: str) -> str:
     elif pattern.match(search_params):
         return search_params.replace('"', "'")
     else:
-        raise SyntaxError(
+        raise ValueError(
             'The search_params directive must be either True, False or ["param1", "param2"].\n'
             'The params name shouldn\'t contain any of the following characters ["\\", "\'", """, ",", "?", "=", "&", " ").'
         )

--- a/jupyterlite_sphinx/jupyterlite_sphinx.py
+++ b/jupyterlite_sphinx/jupyterlite_sphinx.py
@@ -61,7 +61,7 @@ class _PromptedIframe(Element):
             height=height,
             prompt=prompt,
             prompt_color=prompt_color,
-            search_params=search_params
+            search_params=search_params,
         )
 
     def html(self):
@@ -79,7 +79,7 @@ class _PromptedIframe(Element):
             placeholder_id = uuid4()
             container_style = f'width: {self["width"]}; height: {self["height"]};'
 
-            return (f"""
+            return f"""
                 <div
                     class=\"jupyterlite_sphinx_iframe_container\"
                     style=\"{container_style}\"
@@ -96,7 +96,7 @@ class _PromptedIframe(Element):
                     {prompt}
                     </div>
                 </div>
-            """)
+            """
 
         return (
             f'<iframe src="{iframe_src}"'
@@ -257,10 +257,9 @@ class _LiteDirective(SphinxDirective):
         prompt = self.options.pop("prompt", False)
         prompt_color = self.options.pop("prompt_color", None)
 
-        search_params = list(map(
-            str.strip,
-            self.options.pop("search_params", "").split(",")
-        ))
+        search_params = list(
+            map(str.strip, self.options.pop("search_params", "").split(","))
+        )
 
         source_location = os.path.dirname(self.get_source_info()[0])
 

--- a/jupyterlite_sphinx/jupyterlite_sphinx.py
+++ b/jupyterlite_sphinx/jupyterlite_sphinx.py
@@ -4,6 +4,7 @@ import shutil
 import tempfile
 from warnings import warn
 import glob
+import re
 
 from pathlib import Path
 
@@ -501,13 +502,15 @@ def setup(app):
 
 
 def search_params_parser(search_params: str) -> str:
+    pattern = re.compile(r"^\[(?:\s*[\"']{1}([^=\s\,&=\?\/]+)[\"']{1}\s*\,?)+\]$")
     if not search_params:
         return ""
     if search_params in ["True", "False"]:
         return search_params.lower()
-    elif search_params.startswith("[") and search_params.endswith("]"):
+    elif pattern.match(search_params):
         return search_params.replace('"', "'")
     else:
         raise SyntaxError(
-            'The search_params directive must be either True, False or ["param1", "param2"]'
+            'The search_params directive must be either True, False or ["param1", "param2"].\n'
+            'The params name shouldn\'t contain any of the following characters ["\\", "\'", """, ",", "?", "=", "&", " ").'
         )


### PR DESCRIPTION
This PR adds a new directive to allow transfering some search params from the documentation URL to the jupyterlite URL.

Fixes https://github.com/jupyterlite/jupyterlite-sphinx/issues/107