### PR TITLE
Fix search params

### DIFF
--- a/jupyterlite_sphinx/jupyterlite_sphinx.js
+++ b/jupyterlite_sphinx/jupyterlite_sphinx.js
@@ -33,5 +33,9 @@ window.jupyterliteConcatSearchParams = (iframeSrc, params) => {
     }
   });
 
-  return iframeUrl.toString().replace(`${baseURL}/`, '');
+  if (iframeUrl.searchParams.size) {
+    return `${iframeSrc}?${iframeUrl.searchParams.toString()}`;
+  } else {
+    return iframeSrc;
+  }
 }

--- a/jupyterlite_sphinx/jupyterlite_sphinx.js
+++ b/jupyterlite_sphinx/jupyterlite_sphinx.js
@@ -34,7 +34,7 @@ window.jupyterliteConcatSearchParams = (iframeSrc, params) => {
   });
 
   if (iframeUrl.searchParams.size) {
-    return `${iframeSrc}?${iframeUrl.searchParams.toString()}`;
+    return `${iframeSrc.split('?')[0]}?${iframeUrl.searchParams.toString()}`;
   } else {
     return iframeSrc;
   }

--- a/jupyterlite_sphinx/jupyterlite_sphinx.js
+++ b/jupyterlite_sphinx/jupyterlite_sphinx.js
@@ -33,6 +33,5 @@ window.jupyterliteConcatSearchParams = (iframeSrc, params) => {
     }
   });
 
-  let iframeSrc = iframeUrl.toString().replace(baseURL, '');
-  return iframeSrc.replace(/^\//, '');
+  return iframeUrl.toString().replace(`${baseURL}/`, '');
 }

--- a/jupyterlite_sphinx/jupyterlite_sphinx.js
+++ b/jupyterlite_sphinx/jupyterlite_sphinx.js
@@ -33,5 +33,6 @@ window.jupyterliteConcatSearchParams = (iframeSrc, params) => {
     }
   });
 
-  return iframeUrl.toString().replace(baseURL, '');
+  let iframeSrc = iframeUrl.toString().replace(baseURL, '');
+  return iframeSrc.replace(/^\//, '');
 }

--- a/jupyterlite_sphinx/jupyterlite_sphinx.py
+++ b/jupyterlite_sphinx/jupyterlite_sphinx.py
@@ -52,7 +52,7 @@ class _PromptedIframe(Element):
         height="100%",
         prompt=False,
         prompt_color=None,
-        search_params=[],
+        search_params="false",
         **attributes,
     ):
         super().__init__(
@@ -262,7 +262,7 @@ class _LiteDirective(SphinxDirective):
         prompt = self.options.pop("prompt", False)
         prompt_color = self.options.pop("prompt_color", None)
 
-        search_params = search_params_parser(self.options.pop("search_params", ""))
+        search_params = search_params_parser(self.options.pop("search_params", False))
 
         source_location = os.path.dirname(self.get_source_info()[0])
 

--- a/jupyterlite_sphinx/jupyterlite_sphinx.py
+++ b/jupyterlite_sphinx/jupyterlite_sphinx.py
@@ -221,7 +221,7 @@ class RepliteDirective(SphinxDirective):
         prompt = self.options.pop("prompt", False)
         prompt_color = self.options.pop("prompt_color", None)
 
-        search_params = search_params_parser(self.options.pop("search_params", ""))
+        search_params = search_params_parser(self.options.pop("search_params", False))
 
         prefix = os.path.relpath(
             os.path.join(self.env.app.srcdir, JUPYTERLITE_DIR),
@@ -504,7 +504,7 @@ def setup(app):
 def search_params_parser(search_params: str) -> str:
     pattern = re.compile(r"^\[(?:\s*[\"']{1}([^=\s\,&=\?\/]+)[\"']{1}\s*\,?)+\]$")
     if not search_params:
-        return ""
+        return "false"
     if search_params in ["True", "False"]:
         return search_params.lower()
     elif pattern.match(search_params):


### PR DESCRIPTION
Follow up of https://github.com/jupyterlite/jupyterlite-sphinx/pull/108.

Fixes the default value if no search params are provided, and fixes the starting slash in the iframeSrc build.

EDIT:
- if the search_params option was not provided, an argument of the function to concatenate the search params was empty, resulting in a javascript error. After this PR, the default value is `false` for this argument.
- the way the `iframeSrc` was built was not working:
   - it was always starting with a `/` (instead of nothing)
   - if it started with `../` (for example in this documentation), the `../` was removed