### PR TITLE
Add try_examples directive for adding interactivity to sphinx Examples sections

### DIFF
--- a/jupyterlite_sphinx/_try_examples.py
+++ b/jupyterlite_sphinx/_try_examples.py
@@ -122,11 +122,25 @@ def _append_code_cell_and_clear_lines(code_lines, output_lines, notebook):
 def _append_markdown_cell_and_clear_lines(markdown_lines, notebook):
     """Append new markdown cell to notebook, clearing lines."""
     markdown_text = "\n".join(markdown_lines)
-    markdown_text = _process_latex(markdown_text)
     # Convert blocks of LaTeX equations
-    markdownd_text = _process_latex(markdown_text)
+    markdown_text = _process_latex(markdown_text)
+    markdown_text = _strip_ref_identifiers(markdown_text)
     notebook.cells.append(new_markdown_cell(markdown_text))
     markdown_lines.clear()
+
+
+_ref_identifier_pattern = re.compile(r"\[R[a-f0-9]+-(?P<ref_num>\d+)\]_")
+
+def _strip_ref_identifiers(md_text):
+    """Remove identifiers from references in notebook.
+
+    Each docstring gets a unique identifier in order to have unique internal
+    links for each docstring on a page.
+
+    They look like [R4c2dbc17006a-1]_. We strip these out so they don't appear
+    in the notebooks. The above would be replaced with [1]_.
+    """
+    return _ref_identifier_pattern.sub(r"[\g<ref_num>]", md_text)
 
 
 def _process_latex(md_text):

--- a/jupyterlite_sphinx/_try_examples.py
+++ b/jupyterlite_sphinx/_try_examples.py
@@ -224,27 +224,21 @@ def insert_try_examples_directive(lines):
             break
     else:
         # No examples section found
-        return lines
-
+        return lines[:]
     # Increment to the line after "Examples"
     left_index += 1
-
     # Skip empty lines to get to the first content line after "Examples"
     while left_index < len(lines) and not lines[left_index].strip():
         left_index += 1
-
     # If reached the end of the docstring without finding non-empty line
     if left_index == len(lines):
-        return lines
-
+        return lines[:]
     # Check for the "..! disable_try_examples" directive
-    if lines[left_index].strip() == "..! disable_try_examples":
-        return lines
-
+    if lines[left_index].strip() == "..! disable_try_examples::":
+        return lines[:]
     # Check if the ".. try_examples::" directive already exists
-    if ".. try_examples::" in lines[left_index]:
-        return lines
-
+    if ".. try_examples::" == lines[left_index].strip():
+        return lines[:]
     # Find the end of the Examples section
     right_index = left_index
     while right_index < len(lines) and not _next_section_pattern.search(

--- a/jupyterlite_sphinx/_try_examples.py
+++ b/jupyterlite_sphinx/_try_examples.py
@@ -194,7 +194,7 @@ _next_section_pattern = re.compile(
 )
 
 
-def insert_try_examples_directive(lines):
+def insert_try_examples_directive(lines, **options):
     """Adds try_examples directive to Examples section of a docstring.
 
     Hack to allow for a config option to enable try_examples functionality
@@ -249,7 +249,9 @@ def insert_try_examples_directive(lines):
     # Add the ".. try_examples::" directive and indent the content of the Examples section
     new_lines = (
         lines[:left_index]
-        + [".. try_examples::", ""]
+        + [".. try_examples::"]
+        + [f"    :{key}: {value}" for key, value in options.items()]
+        + [""]
         + ["    " + line for line in lines[left_index:right_index]]
         + [""]
         + lines[right_index:]

--- a/jupyterlite_sphinx/_try_examples.py
+++ b/jupyterlite_sphinx/_try_examples.py
@@ -188,8 +188,12 @@ _non_example_docstring_section_headers = (
 _examples_start_pattern = re.compile(r".. (rubric|admonition):: Examples")
 _next_section_pattern = re.compile(
     "|".join(
-        rf".. (rubric|admonition)::\s*{header}"
-        for header in _non_example_docstring_section_headers
+        [
+            rf".. (rubric|admonition)::\s*{header}"
+            for header in _non_example_docstring_section_headers
+        ]
+        # If examples section is last, processed by numpydoc may appear at end.
+        + [r"^\.\. \!\! processed by numpydoc \!\!"]
     )
 )
 

--- a/jupyterlite_sphinx/_try_examples.py
+++ b/jupyterlite_sphinx/_try_examples.py
@@ -49,9 +49,22 @@ def examples_to_notebook(input_lines):
     output_line = None
     inside_multiline_code_block = False
 
+    ignore_directives = [".. plot::", ".. only::"]
+    inside_ignore_directive = False
 
     for line in input_lines:
         line = line.rstrip("\n")
+
+        # Content underneath some directives should be ignored when generating notebook.
+        if any(line.startswith(directive) for directive in ignore_directives):
+            inside_ignore_directive = True
+            continue
+        if inside_ignore_directive:
+            if line == "" or line[0].isspace():
+                continue
+            else:
+                inside_ignore_directive = False
+
         if line.startswith(">>>"):
             if inside_multiline_code_block:
                 # End of a multiline code block.

--- a/jupyterlite_sphinx/_try_examples.py
+++ b/jupyterlite_sphinx/_try_examples.py
@@ -206,7 +206,7 @@ _next_section_pattern = re.compile(
             for header in _non_example_docstring_section_headers
         ]
         # If examples section is last, processed by numpydoc may appear at end.
-        + [r"^\.\.\s+\!\! processed by numpydoc \!\!"]
+        + [r"\!\! processed by numpydoc \!\!"]
         # Attributes section sometimes has no directive.
         + [r":Attributes:"]
     )
@@ -264,6 +264,13 @@ def insert_try_examples_directive(lines, **options):
         lines[right_index]
     ):
         right_index += 1
+    if "!! processed by numpydoc !!" in lines[right_index]:
+        # Sometimes the .. appears on an earlier line than !! processed by numpydoc !!
+        if not re.search(
+                r"\.\.\s+\!\! processed by numpy doc \!\!", lines[right_index]
+        ):
+            while lines[right_index].strip() != "..":
+                right_index -= 1
 
     # Add the ".. try_examples::" directive and indent the content of the Examples section
     new_lines = (

--- a/jupyterlite_sphinx/_try_examples.py
+++ b/jupyterlite_sphinx/_try_examples.py
@@ -206,7 +206,7 @@ _next_section_pattern = re.compile(
             for header in _non_example_docstring_section_headers
         ]
         # If examples section is last, processed by numpydoc may appear at end.
-        + [r"^\.\. \!\! processed by numpydoc \!\!"]
+        + [r"^\.\.\s+\!\! processed by numpydoc \!\!"]
         # Attributes section sometimes has no directive.
         + [r":Attributes:"]
     )

--- a/jupyterlite_sphinx/_try_examples.py
+++ b/jupyterlite_sphinx/_try_examples.py
@@ -49,7 +49,7 @@ def examples_to_notebook(input_lines):
     output_line = None
 
     for line in input_lines:
-        line = line.strip()
+        line = line.rstrip("\n")
         if line.startswith(">>>"):
             # This line is code
             # If there is any pending markdown text, add it to the notebook
@@ -61,7 +61,7 @@ def examples_to_notebook(input_lines):
                 md_lines = []  # Reset markdown lines
             # Add this line to the code
             code_lines.append(line[4:])  # Remove '>>> ' prefix
-        elif line.strip() == "" and code_lines:
+        elif line.rstrip("\n") == "" and code_lines:
             # This line is blank, so it is the end of a code cell
             # If there is any pending code, add it to the notebook
             code_text = "\n".join(code_lines)
@@ -114,24 +114,25 @@ def _process_latex(md_text):
     equation_lines = []
 
     for line in lines:
-        stripped_line = line.strip()
-        if stripped_line == ".. math::":
+        if line.strip() == ".. math::":
             in_math_block = True
             continue  # Skip the '.. math::' line
 
         if in_math_block:
-            if stripped_line == "":
+            if line.strip() == "":
                 if equation_lines:
                     # Join and wrap the equations, then reset
                     wrapped_lines.append(f"$$ {' '.join(equation_lines)} $$")
                     equation_lines = []
             elif line.startswith(" ") or line.startswith("\t"):
-                equation_lines.append(stripped_line)
+                equation_lines.append(line.strip())
         else:
             wrapped_lines.append(line)
 
         # If you leave the indented block, the math block ends
-        if in_math_block and not (line.startswith(" ") or line.startswith("\t")):
+        if in_math_block and not (
+            line.startswith(" ") or line.startswith("\t") or line.strip() == ""
+        ):
             in_math_block = False
             if equation_lines:
                 wrapped_lines.append(f"$$ {' '.join(equation_lines)} $$")
@@ -196,7 +197,7 @@ def insert_try_examples_directive(lines):
     docstring : list of str
         Lines of a docstring at time of "autodoc-process-docstring", with section
         headers denoted by `.. rubric::` or `.. admonition::`.
-        
+
 
     Returns
     -------
@@ -207,7 +208,7 @@ def insert_try_examples_directive(lines):
         is included at the top of the Examples section. Also a no-op if the
         try_examples directive is already included.
     """
-        # Search for the "Examples" section start
+    # Search for the "Examples" section start
     for left_index, line in enumerate(lines):
         if _examples_start_pattern.search(line):
             break

--- a/jupyterlite_sphinx/_try_examples.py
+++ b/jupyterlite_sphinx/_try_examples.py
@@ -116,7 +116,7 @@ def examples_to_notebook(input_lines):
 
 def _process_latex(md_text):
     # Map rst latex directive to $ so latex renders in notebook.
-    md_text = re.sub(r":math:`(?P<latex>.*?)`", r"$\g<latex>$", md_text)
+    md_text = re.sub(r":math:\s*`(?P<latex>.*?)`", r"$\g<latex>$", md_text)
 
     lines = md_text.split("\n")
     in_math_block = False

--- a/jupyterlite_sphinx/_try_examples.py
+++ b/jupyterlite_sphinx/_try_examples.py
@@ -100,15 +100,15 @@ def examples_to_notebook(input_lines):
     if code_lines:
         _append_code_cell_and_clear_lines(code_lines, output_lines, nb)
 
-    nb["metadata"] =  {
+    nb["metadata"] = {
         "kernelspec": {
             "display_name": "Python",
             "language": "python",
-            "name": "python"
+            "name": "python",
         },
         "language_info": {
             "name": "python",
-        }
+        },
     }
     return nb
 
@@ -141,6 +141,7 @@ def _append_markdown_cell_and_clear_lines(markdown_lines, notebook):
 
 
 _ref_identifier_pattern = re.compile(r"\[R[a-f0-9]+-(?P<ref_num>\d+)\]_")
+
 
 def _strip_ref_identifiers(md_text):
     """Remove identifiers from references in notebook.
@@ -303,7 +304,7 @@ def insert_try_examples_directive(lines, **options):
     if "!! processed by numpydoc !!" in lines[right_index]:
         # Sometimes the .. appears on an earlier line than !! processed by numpydoc !!
         if not re.search(
-                r"\.\.\s+\!\! processed by numpy doc \!\!", lines[right_index]
+            r"\.\.\s+\!\! processed by numpy doc \!\!", lines[right_index]
         ):
             while lines[right_index].strip() != "..":
                 right_index -= 1

--- a/jupyterlite_sphinx/_try_examples.py
+++ b/jupyterlite_sphinx/_try_examples.py
@@ -99,6 +99,17 @@ def examples_to_notebook(input_lines):
         _append_markdown_cell_and_clear_lines(md_lines, nb)
     if code_lines:
         _append_code_cell_and_clear_lines(code_lines, output_lines, nb)
+
+    nb["metadata"] =  {
+        "kernelspec": {
+            "display_name": "Python",
+            "language": "python",
+            "name": "python"
+        },
+        "language_info": {
+            "name": "python",
+        }
+    }
     return nb
 
 

--- a/jupyterlite_sphinx/_try_examples.py
+++ b/jupyterlite_sphinx/_try_examples.py
@@ -207,6 +207,8 @@ _next_section_pattern = re.compile(
         ]
         # If examples section is last, processed by numpydoc may appear at end.
         + [r"^\.\. \!\! processed by numpydoc \!\!"]
+        # Attributes section sometimes has no directive.
+        + [r":Attributes:"]
     )
 )
 

--- a/jupyterlite_sphinx/_try_examples.py
+++ b/jupyterlite_sphinx/_try_examples.py
@@ -145,7 +145,9 @@ def _strip_ref_identifiers(md_text):
 
 def _process_latex(md_text):
     # Map rst latex directive to $ so latex renders in notebook.
-    md_text = re.sub(r":math:\s*`(?P<latex>.*?)`", r"$\g<latex>$", md_text)
+    md_text = re.sub(
+        r":math:\s*`(?P<latex>.*?)`", r"$\g<latex>$", md_text, flags=re.DOTALL
+    )
 
     lines = md_text.split("\n")
     in_math_block = False
@@ -176,6 +178,7 @@ def _process_latex(md_text):
             if equation_lines:
                 wrapped_lines.append(f"$$ {' '.join(equation_lines)} $$")
             equation_lines = []
+            wrapped_lines.append(line)
 
     return "\n".join(wrapped_lines)
 

--- a/jupyterlite_sphinx/_try_examples.py
+++ b/jupyterlite_sphinx/_try_examples.py
@@ -253,27 +253,33 @@ def insert_try_examples_directive(lines, **options):
         is included at the top of the Examples section. Also a no-op if the
         try_examples directive is already included.
     """
-    # Search for the "Examples" section start
+    # Search for start of an Examples section
     for left_index, line in enumerate(lines):
         if _examples_start_pattern.search(line):
             break
     else:
-        # No examples section found
+        # No Examples section found
         return lines[:]
-    # Increment to the line after "Examples"
+
+    # Jump to next line
     left_index += 1
-    # Skip empty lines to get to the first content line after "Examples"
+    # Skip empty lines to get to the first content line
     while left_index < len(lines) and not lines[left_index].strip():
         left_index += 1
-    # If reached the end of the docstring without finding non-empty line
     if left_index == len(lines):
+        # Examples section had no content, no need to insert directive.
         return lines[:]
-    # Check for the "..! disable_try_examples" directive
+
+    # Check for the "..! disable_try_examples" comment.
     if lines[left_index].strip() == "..! disable_try_examples::":
+        # If so, do not insert directive.
         return lines[:]
+
     # Check if the ".. try_examples::" directive already exists
     if ".. try_examples::" == lines[left_index].strip():
+        # If so, don't need to insert again.
         return lines[:]
+
     # Find the end of the Examples section
     right_index = left_index
     while right_index < len(lines) and not _next_section_pattern.search(

--- a/jupyterlite_sphinx/_try_examples.py
+++ b/jupyterlite_sphinx/_try_examples.py
@@ -47,10 +47,16 @@ def examples_to_notebook(input_lines):
     code_lines = []
     md_lines = []
     output_line = None
+    inside_multiline_code_block = False
+
 
     for line in input_lines:
         line = line.rstrip("\n")
         if line.startswith(">>>"):
+            if inside_multiline_code_block:
+                # End of a multiline code block.
+                inside_multiline_code_block = False
+
             # This line is code
             # If there is any pending markdown text, add it to the notebook
             if md_lines:
@@ -61,6 +67,10 @@ def examples_to_notebook(input_lines):
                 md_lines = []  # Reset markdown lines
             # Add this line to the code
             code_lines.append(line[4:])  # Remove '>>> ' prefix
+        elif line.startswith("...") and code_lines:
+            # This is a continuation of a multiline code block.
+            inside_multiline_code_block = True
+            code_lines.append(line[4:])
         elif line.rstrip("\n") == "" and code_lines:
             # This line is blank, so it is the end of a code cell
             # If there is any pending code, add it to the notebook

--- a/jupyterlite_sphinx/examples_to_notebook.py
+++ b/jupyterlite_sphinx/examples_to_notebook.py
@@ -1,0 +1,140 @@
+import nbformat as nbf
+from nbformat.v4 import new_code_cell, new_markdown_cell
+import re
+
+
+def examples_to_notebook(input_lines):
+    """Parse examples section of a docstring and convert to Jupyter notebook.
+
+    Parameters
+    ----------
+    input_lines : iterable of str.
+                  Lines within
+
+    Returns
+    -------
+    dict
+        json for a Jupyter Notebook
+
+    Examples
+    --------
+    >>> from jupyterlite_sphinx.generate_notebook import examples_to_notebook
+
+    >>> input_lines = [
+    >>>            "Add two numbers. This block of text will appear as a\n",
+    >>>            "markdown cell. The following block will become a code\n",
+    >>>            "cell with the value 4 contained in the output.",
+    >>>            "\n",
+    >>>            ">>> x = 2\n",
+    >>>            ">>> y = 2\n",
+    >>>            ">>> x + y\n",
+    >>>            "4\n",
+    >>>            "\n",
+    >>>            "Inline LaTeX like :math:`x + y = 4` will be converted\n",
+    >>>            "correctly within markdown cells. As will block LaTeX\n",
+    >>>            "such as\n",
+    >>>            "\n",
+    >>>            ".. math::\n",
+    >>>            "\n",
+    >>>            "    x = 2,\;y = 2
+    >>>            "\n",
+    >>>            "    x + y = 4\n",
+    >>>          ]
+    >>> notebook = examples_to_notebook(input_lines)
+    """
+    nb = nbf.v4.new_notebook()
+
+    code_lines = []
+    md_lines = []
+    output_line = None
+
+    for line in input_lines:
+        line = line.strip()
+        if line.startswith(">>>"):
+            # This line is code
+            # If there is any pending markdown text, add it to the notebook
+            if md_lines:
+                md_text = "\n".join(md_lines)
+                md_text = _process_latex(md_text)
+
+                nb.cells.append(new_markdown_cell(md_text))
+                md_lines = []  # Reset markdown lines
+            # Add this line to the code
+            code_lines.append(line[4:])  # Remove '>>> ' prefix
+        elif line.strip() == "" and code_lines:
+            # This line is blank, so it is the end of a code cell
+            # If there is any pending code, add it to the notebook
+            code_text = "\n".join(code_lines)
+            cell = new_code_cell(code_text)
+            if output_line is not None:
+                cell.outputs.append(
+                    nbf.v4.new_output(
+                        output_type="execute_result", data={"text/plain": output_line}
+                    ),
+                )
+                output_line = None
+            nb.cells.append(cell)
+            code_lines = []  # Reset code lines
+        elif code_lines:
+            # This line is the output of the previous code cell
+            output_line = line
+        else:
+            # This line is markdown
+            md_lines.append(line)
+
+    # If there is any pending markdown or code, add it to the notebook
+    if md_lines:
+        md_text = "\n".join(md_lines)
+        md_text = _process_latex(md_text)
+
+        # Convert blocks of LaTeX equations
+        md_text = _process_latex(md_text)
+
+        nb.cells.append(new_markdown_cell(md_text))
+    if code_lines:
+        code_text = "\n".join(code_lines)
+        cell = new_code_cell(code_text)
+        if output_line is not None:
+            cell.outputs.append(
+                nbf.v4.new_output(
+                    output_type="execute_result", data={"text/plain": output_line}
+                ),
+            )
+        nb.cells.append(cell)
+    return nb
+
+
+def _process_latex(md_text):
+    # Map rst latex directive to $ so latex renders in notebook.
+    md_text = re.sub(r":math:`(?P<latex>.*?)`", r"$\g<latex>$", md_text)
+
+    lines = md_text.split("\n")
+    in_math_block = False
+    wrapped_lines = []
+    equation_lines = []
+
+    for line in lines:
+        stripped_line = line.strip()
+        if stripped_line == ".. math::":
+            in_math_block = True
+            continue  # Skip the '.. math::' line
+
+        if in_math_block:
+            if stripped_line == "":
+                if equation_lines:
+                    # Join and wrap the equations, then reset
+                    wrapped_lines.append(f"$$ {' '.join(equation_lines)} $$")
+                    equation_lines = []
+            elif line.startswith(" ") or line.startswith("\t"):
+                equation_lines.append(stripped_line)
+        else:
+            wrapped_lines.append(line)
+
+        # If you leave the indented block, the math block ends
+        if in_math_block and not (line.startswith(" ") or line.startswith("\t")):
+            in_math_block = False
+            if equation_lines:
+                wrapped_lines.append(f"$$ {' '.join(equation_lines)} $$")
+            equation_lines = []
+
+    return "\n".join(wrapped_lines)

--- a/jupyterlite_sphinx/jupyterlite_sphinx.css
+++ b/jupyterlite_sphinx/jupyterlite_sphinx.css
@@ -68,6 +68,11 @@
     }
 }
 
+.try_examples_iframe_container {
+    position: relative;
+    cursor: pointer;
+}
+
 
 .try_examples_outer_container {
     position: relative;

--- a/jupyterlite_sphinx/jupyterlite_sphinx.css
+++ b/jupyterlite_sphinx/jupyterlite_sphinx.css
@@ -67,3 +67,8 @@
         transform: translateY(-50%) translateX(-50%) scale(1.2);
     }
 }
+
+
+.hidden {
+    display: none;
+}

--- a/jupyterlite_sphinx/jupyterlite_sphinx.css
+++ b/jupyterlite_sphinx/jupyterlite_sphinx.css
@@ -69,6 +69,16 @@
 }
 
 
+.try_examples_outer_container {
+    position: relative;
+}
+
+
+.try_examples_button {
+    float: right;
+}
+
+
 .hidden {
     display: none;
 }

--- a/jupyterlite_sphinx/jupyterlite_sphinx.css
+++ b/jupyterlite_sphinx/jupyterlite_sphinx.css
@@ -74,11 +74,6 @@
 }
 
 
-.try_examples_button {
-    float: right;
-}
-
-
 .hidden {
     display: none;
 }

--- a/jupyterlite_sphinx/jupyterlite_sphinx.js
+++ b/jupyterlite_sphinx/jupyterlite_sphinx.js
@@ -51,17 +51,16 @@ window.tryExamplesShowIframe = (
     let iframe = iframeContainer.querySelector('iframe.jupyterlite_sphinx_raw_iframe');
 
     if (!iframe) {
-	const examples = examplesContainer.querySelector('.try_examples_content');
-	iframe = document.createElement('iframe');
-	iframe.src = iframeSrc;
-	iframe.style.width = '100%';
-	iframe.style.height = `${examples.offsetHeight}px`;
-	iframe.classList.add('jupyterlite_sphinx_raw_iframe');
-	examplesContainer.classList.add("hidden");
-	iframeContainer.appendChild(iframe);
-    }
-    else {
-	examplesContainer.classList.add("hidden");
+	      const examples = examplesContainer.querySelector('.try_examples_content');
+	      iframe = document.createElement('iframe');
+	      iframe.src = iframeSrc;
+	      iframe.style.width = '100%';
+	      iframe.style.height = `${examples.offsetHeight}px`;
+	      iframe.classList.add('jupyterlite_sphinx_raw_iframe');
+	      examplesContainer.classList.add("hidden");
+	      iframeContainer.appendChild(iframe);
+    } else {
+	      examplesContainer.classList.add("hidden");
     }
     iframeParentContainer.classList.remove("hidden");
 }

--- a/jupyterlite_sphinx/jupyterlite_sphinx.js
+++ b/jupyterlite_sphinx/jupyterlite_sphinx.js
@@ -48,7 +48,7 @@ window.tryExamplesShowIframe = (examplesContainerId, iframeContainerId, iframeSr
 
     iframe.src = iframeSrc;
     iframe.width = iframe.height = '100%';
-    iframe.classList.add('try_examples_raw_iframe');
+    iframe.classList.add('jupyterlite_sphinx_raw_iframe');
     examples_container.classList.add("hidden")
     iframe_container.appendChild(iframe);
     iframe_container.classList.remove("hidden")

--- a/jupyterlite_sphinx/jupyterlite_sphinx.js
+++ b/jupyterlite_sphinx/jupyterlite_sphinx.js
@@ -41,15 +41,34 @@ window.jupyterliteConcatSearchParams = (iframeSrc, params) => {
 }
 
 
-window.tryExamplesShowIframe = (examplesContainerId, iframeContainerId, iframeSrc) => {
-    const examples_container = document.getElementById(examplesContainerId)
+window.tryExamplesShowIframe = (
+    examplesContainerId, iframeContainerId, iframeParentContainerId, iframeSrc
+) => {
+    const examples_container = document.getElementById(examplesContainerId);
+    const iframe_parent_container = document.getElementById(iframeParentContainerId);
     const iframe_container = document.getElementById(iframeContainerId);
-    const iframe = document.createElement('iframe');
 
-    iframe.src = iframeSrc;
-    iframe.width = iframe.height = '100%';
-    iframe.classList.add('jupyterlite_sphinx_raw_iframe');
-    examples_container.classList.add("hidden")
-    iframe_container.appendChild(iframe);
-    iframe_container.classList.remove("hidden")
+    let iframe = iframe_container.querySelector('iframe.jupyterlite_sphinx_raw_iframe');
+
+    if (!iframe) {
+	iframe = document.createElement('iframe');
+	iframe.src = iframeSrc;
+	iframe.width = iframe.height = '100%';
+	iframe.classList.add('jupyterlite_sphinx_raw_iframe');
+	examples_container.classList.add("hidden")
+	iframe_container.appendChild(iframe);
+    }
+    else {
+	examples_container.classList.add("hidden");
+    }
+    iframe_parent_container.classList.remove("hidden");
+}
+
+
+window.tryExamplesHideIframe = (examplesContainerId, iframeParentContainerId) => {
+    const examples_container = document.getElementById(examplesContainerId);
+    const iframe_parent_container = document.getElementById(iframeParentContainerId);
+
+    iframe_parent_container.classList.add("hidden");
+    examples_container.classList.remove("hidden");
 }

--- a/jupyterlite_sphinx/jupyterlite_sphinx.js
+++ b/jupyterlite_sphinx/jupyterlite_sphinx.js
@@ -44,31 +44,33 @@ window.jupyterliteConcatSearchParams = (iframeSrc, params) => {
 window.tryExamplesShowIframe = (
     examplesContainerId, iframeContainerId, iframeParentContainerId, iframeSrc
 ) => {
-    const examples_container = document.getElementById(examplesContainerId);
-    const iframe_parent_container = document.getElementById(iframeParentContainerId);
-    const iframe_container = document.getElementById(iframeContainerId);
+    const examplesContainer = document.getElementById(examplesContainerId);
+    const iframeParentContainer = document.getElementById(iframeParentContainerId);
+    const iframeContainer = document.getElementById(iframeContainerId);
 
-    let iframe = iframe_container.querySelector('iframe.jupyterlite_sphinx_raw_iframe');
+    let iframe = iframeContainer.querySelector('iframe.jupyterlite_sphinx_raw_iframe');
 
     if (!iframe) {
+	const examples = examplesContainer.querySelector('.try_examples_content');
 	iframe = document.createElement('iframe');
 	iframe.src = iframeSrc;
-	iframe.width = iframe.height = '100%';
+	iframe.style.width = '100%';
+	iframe.style.height = `${examples.offsetHeight}px`;
 	iframe.classList.add('jupyterlite_sphinx_raw_iframe');
-	examples_container.classList.add("hidden")
-	iframe_container.appendChild(iframe);
+	examplesContainer.classList.add("hidden");
+	iframeContainer.appendChild(iframe);
     }
     else {
-	examples_container.classList.add("hidden");
+	examplesContainer.classList.add("hidden");
     }
-    iframe_parent_container.classList.remove("hidden");
+    iframeParentContainer.classList.remove("hidden");
 }
 
 
 window.tryExamplesHideIframe = (examplesContainerId, iframeParentContainerId) => {
-    const examples_container = document.getElementById(examplesContainerId);
-    const iframe_parent_container = document.getElementById(iframeParentContainerId);
+    const examplesContainer = document.getElementById(examplesContainerId);
+    const iframeParentContainer = document.getElementById(iframeParentContainerId);
 
-    iframe_parent_container.classList.add("hidden");
-    examples_container.classList.remove("hidden");
+    iframeParentContainer.classList.add("hidden");
+    examplesContainer.classList.remove("hidden");
 }

--- a/jupyterlite_sphinx/jupyterlite_sphinx.js
+++ b/jupyterlite_sphinx/jupyterlite_sphinx.js
@@ -39,3 +39,17 @@ window.jupyterliteConcatSearchParams = (iframeSrc, params) => {
     return iframeSrc;
   }
 }
+
+
+window.tryExamplesShowIframe = (examplesContainerId, iframeContainerId, iframeSrc) => {
+    const examples_container = document.getElementById(examplesContainerId)
+    const iframe_container = document.getElementById(iframeContainerId);
+    const iframe = document.createElement('iframe');
+
+    iframe.src = iframeSrc;
+    iframe.width = iframe.height = '100%';
+    iframe.classList.add('try_examples_raw_iframe');
+    examples_container.classList.add("hidden")
+    iframe_container.appendChild(iframe);
+    iframe_container.classList.remove("hidden")
+}

--- a/jupyterlite_sphinx/jupyterlite_sphinx.py
+++ b/jupyterlite_sphinx/jupyterlite_sphinx.py
@@ -379,7 +379,13 @@ class TryExamplesDirective(SphinxDirective):
             directive_key
         )
 
-        prefix = os.path.join("..", JUPYTERLITE_DIR)
+        # We need to get the relative path back to the documentation root from
+        # whichever file the docstring content is in.
+        docname = self.env.docname
+        depth = len(docname.split("/")) - 1
+        relative_path_to_root = '/'.join(['..'] * depth)
+        prefix = os.path.join(relative_path_to_root, JUPYTERLITE_DIR)
+
         lite_app = "retro/"
         notebooks_path = "notebooks/"
 

--- a/jupyterlite_sphinx/jupyterlite_sphinx.py
+++ b/jupyterlite_sphinx/jupyterlite_sphinx.py
@@ -364,6 +364,7 @@ class RetroLiteParser(RSTParser):
 
 class TryExamplesDirective(SphinxDirective):
     """Add button to try doctest examples in Jupyterlite notebook."""
+
     has_content = True
     required_arguments = 0
     option_spec = {
@@ -372,11 +373,11 @@ class TryExamplesDirective(SphinxDirective):
     }
 
     def run(self):
-        if 'generated_notebooks' not in self.env.temp_data:
-            self.env.temp_data['generated_notebooks'] = {}
+        if "generated_notebooks" not in self.env.temp_data:
+            self.env.temp_data["generated_notebooks"] = {}
 
         directive_key = f"{self.env.docname}-{self.lineno}"
-        notebook_unique_name = self.env.temp_data['generated_notebooks'].get(
+        notebook_unique_name = self.env.temp_data["generated_notebooks"].get(
             directive_key
         )
 
@@ -384,18 +385,20 @@ class TryExamplesDirective(SphinxDirective):
         # whichever file the docstring content is in.
         docname = self.env.docname
         depth = len(docname.split("/")) - 1
-        relative_path_to_root = '/'.join(['..'] * depth)
+        relative_path_to_root = "/".join([".."] * depth)
         prefix = os.path.join(relative_path_to_root, JUPYTERLITE_DIR)
 
         lite_app = "retro/"
         notebooks_path = "notebooks/"
 
-        content_container_node = nodes.container(classes=["try_examples_outer_container"])
+        content_container_node = nodes.container(
+            classes=["try_examples_outer_container"]
+        )
         examples_div_id = uuid4()
-        content_container_node['ids'].append(examples_div_id)
+        content_container_node["ids"].append(examples_div_id)
         # Parse the original content to create nodes
         content_node = nodes.container()
-        content_node['classes'].append("try_examples_content")
+        content_node["classes"].append("try_examples_content")
         self.state.nested_parse(self.content, self.content_offset, content_node)
         content_container_node += content_node
 
@@ -404,8 +407,9 @@ class TryExamplesDirective(SphinxDirective):
             self.content = None
             notebooks_dir = Path(self.env.app.srcdir) / CONTENT_DIR
             notebook_unique_name = f"{uuid4()}.ipynb".replace("-", "_")
-            self.env.temp_data['generated_notebooks'][directive_key] = \
-                notebook_unique_name
+            self.env.temp_data["generated_notebooks"][
+                directive_key
+            ] = notebook_unique_name
             # Copy the Notebook for RetroLite to find
             os.makedirs(notebooks_dir, exist_ok=True)
             with open(notebooks_dir / Path(notebook_unique_name), "w") as f:
@@ -424,20 +428,20 @@ class TryExamplesDirective(SphinxDirective):
 
         # Parent container (initially hidden)
         iframe_parent_container_div_start = (
-            f"<div id=\"{iframe_parent_div_id}\" "
-            f"class=\"try_examples_outer_container hidden\">"
+            f'<div id="{iframe_parent_div_id}" '
+            f'class="try_examples_outer_container hidden">'
         )
 
         iframe_parent_container_div_end = "</div>"
         iframe_container_div = (
-            f"<div id=\"{iframe_div_id}\" "
-            f"class=\"try_examples_iframe_container\">"
+            f'<div id="{iframe_div_id}" '
+            f'class="try_examples_iframe_container">'
             f"</div>"
         )
 
         # Button with the onclick event to swap embedded notebook back to examples.
         go_back_button_html = (
-            "<button class=\"try_examples_button\" "
+            '<button class="try_examples_button" '
             f"onclick=\"window.tryExamplesHideIframe('{examples_div_id}',"
             f"'{iframe_parent_div_id}')\">"
             "Go Back</button>"
@@ -450,16 +454,16 @@ class TryExamplesDirective(SphinxDirective):
             + go_back_button_html
             + iframe_parent_container_div_end
         )
-        notebook_container = nodes.raw('', notebook_container_html, format='html')
+        notebook_container = nodes.raw("", notebook_container_html, format="html")
 
         # Button with the onclick event to swap examples with embedded notebook.
         try_it_button_html = (
-            "<button class=\"try_examples_button\" "
+            '<button class="try_examples_button" '
             f"onclick=\"window.tryExamplesShowIframe('{examples_div_id}',"
             f"'{iframe_div_id}','{iframe_parent_div_id}','{iframe_src}')\">"
             "Try it with JupyterLite!</button>"
         )
-        try_it_button_node = nodes.raw('', try_it_button_html, format='html')
+        try_it_button_node = nodes.raw("", try_it_button_html, format="html")
         # Add the button to the content_container_node
         content_container_node += try_it_button_node
 
@@ -469,7 +473,7 @@ class TryExamplesDirective(SphinxDirective):
 
         try_examples_button_css = f".try_examples_button {{{try_examples_button_css}}}"
         style_tag = nodes.raw(
-            '', f'<style>{try_examples_button_css}</style>', format='html'
+            "", f"<style>{try_examples_button_css}</style>", format="html"
         )
 
         return [content_container_node, notebook_container, style_tag]
@@ -592,19 +596,12 @@ def setup(app):
     app.add_config_value("jupyterlite_dir", app.srcdir, rebuild="html")
     app.add_config_value("jupyterlite_contents", None, rebuild="html")
     app.add_config_value("jupyterlite_bind_ipynb_suffix", True, rebuild="html")
-    app.add_config_value(
-        "global_enable_try_examples", default=False, rebuild=True
-    )
+    app.add_config_value("global_enable_try_examples", default=False, rebuild=True)
     app.add_config_value(
         "try_examples_global_button_css", default="float: right;", rebuild="html"
     )
-    app.add_config_value(
-        "try_examples_global_toolbar", default=None, rebuild=True
-    )
-    app.add_config_value(
-        "try_examples_global_theme", default=None, rebuild=True
-    )
-
+    app.add_config_value("try_examples_global_toolbar", default=None, rebuild=True)
+    app.add_config_value("try_examples_global_theme", default=None, rebuild=True)
 
     # Initialize RetroLite and JupyterLite directives
     app.add_node(
@@ -650,7 +647,7 @@ def setup(app):
 
     # Initialize TryExamples directive
     app.add_directive("try_examples", TryExamplesDirective)
-    app.connect('config-inited', conditional_process_examples)
+    app.connect("config-inited", conditional_process_examples)
 
     # CSS and JS assets
     copy_asset(str(HERE / "jupyterlite_sphinx.css"), str(Path(app.outdir) / "_static"))

--- a/jupyterlite_sphinx/jupyterlite_sphinx.py
+++ b/jupyterlite_sphinx/jupyterlite_sphinx.py
@@ -1,4 +1,5 @@
 import os
+import json
 from uuid import uuid4
 import shutil
 import tempfile
@@ -408,7 +409,8 @@ class TryExamplesDirective(SphinxDirective):
             # Copy the Notebook for RetroLite to find
             os.makedirs(notebooks_dir, exist_ok=True)
             with open(notebooks_dir / Path(notebook_unique_name), "w") as f:
-                nbf.write(nb, f)
+                # nbf.write incorrectly formats multiline arrays in output.
+                json.dump(nb, f, indent=4, ensure_ascii=False)
 
         self.options["path"] = notebook_unique_name
         app_path = f"{lite_app}{notebooks_path}"

--- a/jupyterlite_sphinx/jupyterlite_sphinx.py
+++ b/jupyterlite_sphinx/jupyterlite_sphinx.py
@@ -455,7 +455,7 @@ class TryExamplesDirective(SphinxDirective):
         # Iframe container (initially hidden)
         iframe_container_div = (
             f"<div id=\"{iframe_div_id}\" "
-            f"class=\"try_examples_iframe_container hidden\" "
+            f"class=\"jupyterlite_sphinx_iframe_container hidden\" "
             f"style=\"{container_style}\"></div>"
         )
         iframe_container = nodes.raw('', iframe_container_div, format='html')

--- a/jupyterlite_sphinx/jupyterlite_sphinx.py
+++ b/jupyterlite_sphinx/jupyterlite_sphinx.py
@@ -464,8 +464,16 @@ class TryExamplesDirective(SphinxDirective):
         # Add the button to the content_container_node
         content_container_node += try_it_button_node
 
-        # Return the outer container node
-        return [content_container_node, notebook_container]
+        # Allow css for button to be specified in conf.py
+        config = self.state.document.settings.env.config
+        try_examples_button_css = config.jupyterlite_try_examples_button_css
+
+        try_examples_button_css = f".try_examples_button {{{try_examples_button_css}}}"
+        style_tag = nodes.raw(
+            '', f'<style>{try_examples_button_css}</style>', format='html'
+        )
+
+        return [content_container_node, notebook_container, style_tag]
 
 
 def _process_docstring_examples(app, docname, source):
@@ -481,7 +489,7 @@ def _process_autodoc_docstrings(app, what, name, obj, options, lines):
 
 
 def conditional_process_examples(app, config):
-    if config.global_enable_try_examples:
+    if config.jupyterlite_global_enable_try_examples:
         app.connect("source-read", _process_docstring_examples)
         app.connect("autodoc-process-docstring", _process_autodoc_docstrings)
 
@@ -578,6 +586,13 @@ def setup(app):
     app.add_config_value("jupyterlite_dir", app.srcdir, rebuild="html")
     app.add_config_value("jupyterlite_contents", None, rebuild="html")
     app.add_config_value("jupyterlite_bind_ipynb_suffix", True, rebuild="html")
+    app.add_config_value(
+        "jupyterlite_try_examples_button_css", default="float: right;", rebuild="html"
+    )
+    app.add_config_value(
+        "jupyterlite_global_enable_try_examples", default=False, rebuild=True
+    )
+
 
     # Initialize RetroLite and JupyterLite directives
     app.add_node(
@@ -623,7 +638,6 @@ def setup(app):
 
     # Initialize TryExamples directive
     app.add_directive("try_examples", TryExamplesDirective)
-    app.add_config_value('global_enable_try_examples', default=False, rebuild=True)
     app.connect('config-inited', conditional_process_examples)
 
     # CSS and JS assets

--- a/jupyterlite_sphinx/jupyterlite_sphinx.py
+++ b/jupyterlite_sphinx/jupyterlite_sphinx.py
@@ -465,7 +465,7 @@ class TryExamplesDirective(SphinxDirective):
 
         # Allow css for button to be specified in conf.py
         config = self.state.document.settings.env.config
-        try_examples_button_css = config.try_examples_button_css
+        try_examples_button_css = config.try_examples_global_button_css
 
         try_examples_button_css = f".try_examples_button {{{try_examples_button_css}}}"
         style_tag = nodes.raw(
@@ -483,8 +483,8 @@ def _process_docstring_examples(app, docname, source):
 
 def _process_autodoc_docstrings(app, what, name, obj, options, lines):
     try_examples_options = {
-        "toolbar": app.config.try_examples_toolbar,
-        "theme": app.config.try_examples_theme,
+        "toolbar": app.config.try_examples_global_toolbar,
+        "theme": app.config.try_examples_global_theme,
     }
     try_examples_options = {
         key: value for key, value in try_examples_options.items() if value is not None
@@ -593,16 +593,16 @@ def setup(app):
     app.add_config_value("jupyterlite_contents", None, rebuild="html")
     app.add_config_value("jupyterlite_bind_ipynb_suffix", True, rebuild="html")
     app.add_config_value(
-        "try_examples_button_css", default="float: right;", rebuild="html"
-    )
-    app.add_config_value(
         "global_enable_try_examples", default=False, rebuild=True
     )
     app.add_config_value(
-        "try_examples_toolbar", default=None, rebuild=True
+        "try_examples_global_button_css", default="float: right;", rebuild="html"
     )
     app.add_config_value(
-        "try_examples_theme", default=None, rebuild=True
+        "try_examples_global_toolbar", default=None, rebuild=True
+    )
+    app.add_config_value(
+        "try_examples_global_theme", default=None, rebuild=True
     )
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "jupyter_server",
     "jupyterlab_server",
     "jupyterlite-core >=0.1.0",
+    "nbformat",
     "sphinx>=4",
 ]
 


### PR DESCRIPTION
#### Reference issue
closes gh-105.

#### What does this implement/fix?
This PR adds the `try_examples` directive, which takes Examples sections like below

![image](https://github.com/jupyterlite/jupyterlite-sphinx/assets/1953382/311ae7f2-7435-4f78-a7b2-a4d81e6b7b6a)


and generates notebooks based on them, providing a button to swap the example content in place with a notebook

![image](https://github.com/jupyterlite/jupyterlite-sphinx/assets/1953382/ccb64127-0072-4ca9-81de-6a78985490e4)

#### Additional information
You can find this deployed for the SciPy documentation here, https://steppi.github.io/scipy/. I've managed to fix a lot of small bugs in notebook generation and this has finally got to the state where I haven't found any issues on that front in the SciPy docs.

For content under the `.. try_examples::` directive, doctest blocks are turned into code cells and RST text blocks are turned into markdown cells. Both inline and block math is handled so that the math displays correctly in the notebooks, as seen above.

To avoid having to manually add the directive, I've created a `global_enable_try_examples` config option, which automatically inserts the directive within Examples sections during the `autodoc-process-docstring` phase. This requires the docstring to be in the format produced by `numpydoc` during this phase ( I think this is format is also produced by `sphinx.ext.napoleon`.) It will need to be clearly documented how to set things up so that `global_enable_try_examples` will work. At the moment I've only tested this with SciPy's documentation, which has NumPy style docstrings and used the following extensions

```python
extensions = [
    'sphinx.ext.autodoc',
    'sphinx.ext.autosummary',
    'sphinx.ext.coverage',
    'sphinx.ext.mathjax',
    'sphinx.ext.intersphinx',
    'numpydoc',
    'sphinx_design',
    'scipyoptdoc',
    'doi_role',
    'matplotlib.sphinxext.plot_directive',
    'myst_nb',
    'jupyterlite_sphinx',
]
```

I've added handling for math with `sphinx.ext.mathjax`, worked around cruft added by `matplotlib.sphinxext.plot_directive` that shouldn't go into notebooks, and cleaned up the raw output for references produced by `numpydoc` so it looks nicer in the notebooks. Other extensions and workflows may cause issues, particularly if using `global_enable_try_examples`. Using the directive directly on a vanilla docstring should work fine.

For, now I've set the heights of the iframes for the generated notebooks to be the same as the heights of the rendered Examples content. This works pretty well in most cases, but looks bad for particularly short Examples sections. I plan to make this more configurable, but would appreciate feedback on the best way to do that. For now there are configuration options for the whether or not the toolbar should appear by default, the jupyterlite theme, and the css for relevant buttons. I think configuration should be more flexible.

I haven't documented the extension yet, but clear documentation will be very important.

@martinRenou I have one important question. At least for Firefox, I've found that my browser prompts me to select a kernel every time I open one of the generated notebooks, even though Pyodide is the only kernel installed. You can try that out [here](https://steppi.github.io/scipy/reference/index.html). I think this will be too annoying for users, so hope there is a way the kernel can be specified in advance.