### PR TITLE
Add option to disable TryExamples without rebuilding docs

### DIFF
--- a/docs/directives/try_examples.md
+++ b/docs/directives/try_examples.md
@@ -167,16 +167,16 @@ If you are using the `TryExamples` directive in your documentation, you'll need 
 that the version of the package installed in the Jupyterlite kernel you are using
 matches that of the version you are documenting.
 
-## Disable without rebuilding
+## Configuration without rebuilding
 The `TryExamples` directive supports disabling interactive examples without rebuilding
 the documentation. This can be helpful for projects requiring substantial documentation
-build time. Users may add a json file entitled `.try_examples_ignore.json` to the root
+build time. Users may add a json config file entitled `.try_examples.json` to the root
 directory of the build directory for the deployed documentation. The format is a list of
-[JavaScript Regex patterns](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_expressions) attached to the key `"patterns"` like below.
+[JavaScript Regex patterns](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_expressions) attached to the key `"ignore_patterns"` like below.
 
 ```json
 {
-    "patterns": ["^latest/.*", "^stable/reference/generated/example"]
+    "ignore_patterns": ["^latest/.*", "^stable/reference/generated/example"]
 }
 ```
 

--- a/docs/directives/try_examples.md
+++ b/docs/directives/try_examples.md
@@ -166,3 +166,9 @@ allowing for specification of examples sections which should not be made interac
 If you are using the `TryExamples` directive in your documentation, you'll need to ensure
 that the version of the package installed in the Jupyterlite kernel you are using
 matches that of the version you are documenting.
+
+## Disable without rebuilding
+Adding a file entitled `.disable_try_examples` to the root of your documentation's build
+directory will cause try examples buttons to be hidden at page load time, effectively
+disabling interactive examples without requiring a documentation rebuild. This can be
+helpful for projects requiring substantial documentation build time.

--- a/docs/directives/try_examples.md
+++ b/docs/directives/try_examples.md
@@ -195,3 +195,12 @@ Note that these patterns should match the Sphinx docnames of the documentation f
 A docname is the relative path from the documentation root to the file of interest,
 but without the file extension. For instance, the docname corresponding to `index.rst` at
 the root of the Sphinx source directory would be `index`.
+
+A default configuration file can be specified in `conf.py` with the option
+`try_examples_default_runtime_config`.
+
+```python
+try_examples_default_runtime_config = {
+    "ignore_patterns": ["^latest/.*", "^stable/reference/generated/example"]
+}
+```

--- a/docs/directives/try_examples.md
+++ b/docs/directives/try_examples.md
@@ -168,7 +168,30 @@ that the version of the package installed in the Jupyterlite kernel you are usin
 matches that of the version you are documenting.
 
 ## Disable without rebuilding
-Adding a file entitled `.disable_try_examples` to the root of your documentation's build
-directory will cause try examples buttons to be hidden at page load time, effectively
-disabling interactive examples without requiring a documentation rebuild. This can be
-helpful for projects requiring substantial documentation build time.
+The `TryExamples` directive supports disabling interactive examples without rebuilding
+the documentation. This can be helpful for projects requiring substantial documentation
+build time. Users may add a json file entitled `.try_examples_ignore.json` to the root
+directory of the build directory for the deployed documentation. The format is a list of
+[JavaScript Regex patterns](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_expressions) attached to the key `"patterns"` like below.
+
+```json
+{
+    "patterns": ["^latest/.*", "^stable/reference/generated/example"]
+}
+```
+
+`TryExamples` buttons will be hidden in files matching at least one of these patterns,
+effectively disabling the interactive documentation. In the provided example:
+
+* The pattern `"^latest/.*" disables interactive examples for all files within the
+  latest directory, which may be useful if this directory contains documentation
+  for a development version for which corresponding package build is not available
+  in a Jupyterlite kernel.
+
+* The pattern `"^stable/reference/generated/example"` targets a particular file
+  in the documentation for the latest stable release. 
+
+Note that these patterns should match the Sphinx docnames of the documentation files.
+A docname is the relative path from the documentation root to the file of interest,
+but without the file extension. For instance, the docname corresponding to `index.rst` at
+the root of the Sphinx source directory would be `index`.

--- a/docs/directives/try_examples.md
+++ b/docs/directives/try_examples.md
@@ -177,31 +177,30 @@ directory of the build directory for the deployed documentation. The format is a
 
 ```json
 {
-    "ignore_patterns": ["^latest/.*", "^stable/reference/generated/example"]
+    "ignore_patterns": ["^/latest/.*", "^/stable/reference/generated/example.html"]
 }
 ```
 
-`TryExamples` buttons will be hidden in files matching at least one of these patterns,
-effectively disabling the interactive documentation. In the provided example:
+`TryExamples` buttons will be hidden in url pathnames matching at least one of these
+patterns, effectively disabling the interactive documentation. In the provided example:
 
-* The pattern `"^latest/.*" disables interactive examples for all files within the
-  latest directory, which may be useful if this directory contains documentation
-  for a development version for which corresponding package build is not available
+* The pattern `".*latest/.*" disables interactive examples for urls for the documentation
+  for the latest version of the package, which may be useful if this documentation is
+  for a development version for which a corresponding package build is not available
   in a Jupyterlite kernel.
 
-* The pattern `"^stable/reference/generated/example"` targets a particular file
+* The pattern `".*stable/reference/generated/example.html"` targets a particular url
   in the documentation for the latest stable release. 
 
-Note that these patterns should match the Sphinx docnames of the documentation files.
-A docname is the relative path from the documentation root to the file of interest,
-but without the file extension. For instance, the docname corresponding to `index.rst` at
-the root of the Sphinx source directory would be `index`.
+Note that these patterns should match the [pathname](https://developer.mozilla.org/en-US/docs/Web/API/Location/pathname) of the url, not the full url. This is the path portion of
+the url. For instance, the pathname of https://jupyterlite-sphinx.readthedocs.io/en/latest/directives/try_examples.html is `/en/latest/directives/try_examples.html`.
+
 
 A default configuration file can be specified in `conf.py` with the option
 `try_examples_default_runtime_config`.
 
 ```python
 try_examples_default_runtime_config = {
-    "ignore_patterns": ["^latest/.*", "^stable/reference/generated/example"]
+    "ignore_patterns": ["^/latest/.*", "^/stable/reference/generated/example.html"]
 }
 ```

--- a/docs/directives/try_examples.md
+++ b/docs/directives/try_examples.md
@@ -168,6 +168,7 @@ that the version of the package installed in the Jupyterlite kernel you are usin
 matches that of the version you are documenting.
 
 ## Configuration without rebuilding
+
 The `TryExamples` directive supports disabling interactive examples without rebuilding
 the documentation. This can be helpful for projects requiring substantial documentation
 build time. Users may add a json config file entitled `.try_examples.json` to the root

--- a/jupyterlite_sphinx/jupyterlite_sphinx.js
+++ b/jupyterlite_sphinx/jupyterlite_sphinx.js
@@ -78,42 +78,43 @@ window.tryExamplesHideIframe = (examplesContainerId, iframeParentContainerId) =>
 }
 
 
-window.loadTryExamplesConfig = (ignoreFilePath) => {
-    // Add a timestamp as query parameter to ensure a cached version of the
-    // file is not used.
-    const timestamp = new Date().getTime();
-    const ignoreFileUrl = `${ignoreFilePath}?cb=${timestamp}`;
-    const currentPageUrl = window.location.pathname;
-    fetch(ignoreFileUrl)
-        .then(response => {
-            if (!response.ok) {
-                if (response.status === 404) {
-                    // try examples ignore file is not present.
-                    return null;
-                }
-                throw new Error(`Error fetching ${ignoreFilePath}`);
-            }
-            return response.json();
-        })
-        .then(data => {
-            if (!data) {
+window.loadTryExamplesConfig = async (ignoreFilePath) => {
+    try {
+        // Add a timestamp as query parameter to ensure a cached version of the
+        // file is not used.
+        const timestamp = new Date().getTime();
+        const ignoreFileUrl = `${ignoreFilePath}?cb=${timestamp}`;
+        const currentPageUrl = window.location.pathname;
+
+        const response = await fetch(ignoreFileUrl);
+        if (!response.ok) {
+            if (response.status === 404) {
+                // Try examples ignore file is not present.
+                console.log('Ignore file not found.');
                 return;
             }
-            // Disable interactive examples if file matches one of the ignore patterns
-            // by hiding try_examples_buttons.
-            const regexPatterns = data.ignore_patterns;
-            for (let pattern of regexPatterns) {
-                let regex = new RegExp(pattern);
-                if (regex.test(currentPageUrl)) {
-                    var buttons = document.getElementsByClassName('try_examples_button');
-                    for (var i = 0; i < buttons.length; i++) {
-                        buttons[i].classList.add('hidden');
-                    }
-                    break;
+            throw new Error(`Error fetching ${ignoreFilePath}`);
+        }
+
+        const data = await response.json();
+        if (!data) {
+            return;
+        }
+
+        // Disable interactive examples if file matches one of the ignore patterns
+        // by hiding try_examples_buttons.
+        Patterns = data.ignore_patterns;
+        for (let pattern of Patterns) {
+            let regex = new RegExp(pattern);
+            if (regex.test(currentPageUrl)) {
+                var buttons = document.getElementsByClassName('try_examples_button');
+                for (var i = 0; i < buttons.length; i++) {
+                    buttons[i].classList.add('hidden');
                 }
+                break;
             }
-        })
-        .catch(error => {
-            console.error(error);
-        });
+        }
+    } catch (error) {
+        console.error(error);
+    }
 };

--- a/jupyterlite_sphinx/jupyterlite_sphinx.js
+++ b/jupyterlite_sphinx/jupyterlite_sphinx.js
@@ -78,11 +78,12 @@ window.tryExamplesHideIframe = (examplesContainerId, iframeParentContainerId) =>
 }
 
 
-window.loadTryExamplesConfig = (ignoreFilePath, currentPagePath) => {
+window.loadTryExamplesConfig = (ignoreFilePath) => {
     // Add a timestamp as query parameter to ensure a cached version of the
     // file is not used.
     const timestamp = new Date().getTime();
     const ignoreFileUrl = `${ignoreFilePath}?cb=${timestamp}`;
+    const currentPageUrl = window.location.pathname;
     fetch(ignoreFileUrl)
         .then(response => {
             if (!response.ok) {
@@ -103,7 +104,7 @@ window.loadTryExamplesConfig = (ignoreFilePath, currentPagePath) => {
             const regexPatterns = data.ignore_patterns;
             for (let pattern of regexPatterns) {
                 let regex = new RegExp(pattern);
-                if (regex.test(currentPagePath)) {
+                if (regex.test(currentPageUrl)) {
                     var buttons = document.getElementsByClassName('try_examples_button');
                     for (var i = 0; i < buttons.length; i++) {
                         buttons[i].classList.add('hidden');

--- a/jupyterlite_sphinx/jupyterlite_sphinx.js
+++ b/jupyterlite_sphinx/jupyterlite_sphinx.js
@@ -76,3 +76,18 @@ window.tryExamplesHideIframe = (examplesContainerId, iframeParentContainerId) =>
     iframeParentContainer.classList.add("hidden");
     examplesContainer.classList.remove("hidden");
 }
+
+
+window.checkDisableTryExamples = (relativePathToRoot) => {
+    const timestamp = new Date().getTime();
+    // Add a dummy query string to avoid problems due to file being cached.
+    const disableFileUrl = `${relativePathToRoot}/.disable_try_examples?cb=${timestamp}`
+    fetch(disableFileUrl).then(response => {
+	if (response.ok) {
+            var buttons = document.getElementsByClassName('try_examples_button');
+            for (var i = 0; i < buttons.length; i++) {
+		buttons[i].classList.add('hidden');
+            }
+	}
+    });
+}

--- a/jupyterlite_sphinx/jupyterlite_sphinx.js
+++ b/jupyterlite_sphinx/jupyterlite_sphinx.js
@@ -98,8 +98,8 @@ window.loadTryExamplesConfig = (ignoreFilePath, currentPagePath) => {
             if (!data) {
                 return;
             }
-	    // Disable interactive examples if file matches one of the ignore patterns
-	    // by hiding try_examples_buttons.
+            // Disable interactive examples if file matches one of the ignore patterns
+            // by hiding try_examples_buttons.
             const regexPatterns = data.ignore_patterns;
             for (let pattern of regexPatterns) {
                 let regex = new RegExp(pattern);

--- a/jupyterlite_sphinx/jupyterlite_sphinx.js
+++ b/jupyterlite_sphinx/jupyterlite_sphinx.js
@@ -79,7 +79,11 @@ window.tryExamplesHideIframe = (examplesContainerId, iframeParentContainerId) =>
 
 
 window.checkTryExamplesIgnore = (ignoreFilePath, currentPagePath) => {
-    fetch(ignoreFilePath)
+    // Add a timestamp as query parameter to ensure a cached version of the
+    // file is not used.
+    const timestamp = new Date().getTime();
+    const ignoreFileUrl = `${ignoreFilePath}?cb=${timestamp}`;
+    fetch(ignoreFileUrl)
         .then(response => {
             if (!response.ok) {
                 if (response.status === 404) {

--- a/jupyterlite_sphinx/jupyterlite_sphinx.js
+++ b/jupyterlite_sphinx/jupyterlite_sphinx.js
@@ -52,18 +52,18 @@ window.tryExamplesShowIframe = (
     let iframe = iframeContainer.querySelector('iframe.jupyterlite_sphinx_raw_iframe');
 
     if (!iframe) {
-	      const examples = examplesContainer.querySelector('.try_examples_content');
-	      iframe = document.createElement('iframe');
-	      iframe.src = iframeSrc;
-	      iframe.style.width = '100%';
+              const examples = examplesContainer.querySelector('.try_examples_content');
+              iframe = document.createElement('iframe');
+              iframe.src = iframeSrc;
+              iframe.style.width = '100%';
               minHeight = parseInt(iframeMinHeight);
-	      height = Math.max(minHeight, examples.offsetHeight);
-	      iframe.style.height = `${height}px`;
-	      iframe.classList.add('jupyterlite_sphinx_raw_iframe');
-	      examplesContainer.classList.add("hidden");
-	      iframeContainer.appendChild(iframe);
+              height = Math.max(minHeight, examples.offsetHeight);
+              iframe.style.height = `${height}px`;
+              iframe.classList.add('jupyterlite_sphinx_raw_iframe');
+              examplesContainer.classList.add("hidden");
+              iframeContainer.appendChild(iframe);
     } else {
-	      examplesContainer.classList.add("hidden");
+              examplesContainer.classList.add("hidden");
     }
     iframeParentContainer.classList.remove("hidden");
 }
@@ -83,11 +83,11 @@ window.checkDisableTryExamples = (relativePathToRoot) => {
     // Add a dummy query string to avoid problems due to file being cached.
     const disableFileUrl = `${relativePathToRoot}/.disable_try_examples?cb=${timestamp}`
     fetch(disableFileUrl).then(response => {
-	if (response.ok) {
+        if (response.ok) {
             var buttons = document.getElementsByClassName('try_examples_button');
             for (var i = 0; i < buttons.length; i++) {
-		buttons[i].classList.add('hidden');
+                buttons[i].classList.add('hidden');
             }
-	}
+        }
     });
 }

--- a/jupyterlite_sphinx/jupyterlite_sphinx.js
+++ b/jupyterlite_sphinx/jupyterlite_sphinx.js
@@ -78,7 +78,7 @@ window.tryExamplesHideIframe = (examplesContainerId, iframeParentContainerId) =>
 }
 
 
-window.checkTryExamplesIgnore = (ignoreFilePath, currentPagePath) => {
+window.loadTryExamplesConfig = (ignoreFilePath, currentPagePath) => {
     // Add a timestamp as query parameter to ensure a cached version of the
     // file is not used.
     const timestamp = new Date().getTime();
@@ -98,7 +98,9 @@ window.checkTryExamplesIgnore = (ignoreFilePath, currentPagePath) => {
             if (!data) {
                 return;
             }
-            const regexPatterns = data.patterns;
+	    // Disable interactive examples if file matches one of the ignore patterns
+	    // by hiding try_examples_buttons.
+            const regexPatterns = data.ignore_patterns;
             for (let pattern of regexPatterns) {
                 let regex = new RegExp(pattern);
                 if (regex.test(currentPagePath)) {

--- a/jupyterlite_sphinx/jupyterlite_sphinx.js
+++ b/jupyterlite_sphinx/jupyterlite_sphinx.js
@@ -118,3 +118,15 @@ window.loadTryExamplesConfig = async (ignoreFilePath) => {
         console.error(error);
     }
 };
+
+
+window.toggleTryExamplesButtons = () => {
+    /* Toggle visibility of TryExamples buttons. For use in console for debug
+     * purposes. */
+    var buttons = document.getElementsByClassName('try_examples_button');
+
+    for (var i = 0; i < buttons.length; i++) {
+        buttons[i].classList.toggle('hidden');
+    }
+
+};

--- a/jupyterlite_sphinx/jupyterlite_sphinx.py
+++ b/jupyterlite_sphinx/jupyterlite_sphinx.py
@@ -532,7 +532,7 @@ class TryExamplesDirective(SphinxDirective):
 
         # For disabling interactive examples without rebuilding. Check for
         # .try_examples_ignore file and hide button if it is present.
-        ignore_path = os.path.join(relative_path_to_root, '.try_examples_ignore.json')
+        ignore_path = os.path.join(relative_path_to_root, ".try_examples_ignore.json")
         script_html = (
             "<script>"
             'document.addEventListener("DOMContentLoaded", function() {'

--- a/jupyterlite_sphinx/jupyterlite_sphinx.py
+++ b/jupyterlite_sphinx/jupyterlite_sphinx.py
@@ -531,11 +531,12 @@ class TryExamplesDirective(SphinxDirective):
         )
 
         # For disabling interactive examples without rebuilding. Check for
-        # .disable_try_examples file and hide button if it is present.
+        # .try_examples_ignore file and hide button if it is present.
+        ignore_path = os.path.join(relative_path_to_root, '.try_examples_ignore.json')
         script_html = (
             "<script>"
             'document.addEventListener("DOMContentLoaded", function() {'
-            f'    window.checkDisableTryExamples("{relative_path_to_root}");'
+            f'window.checkTryExamplesIgnore("{ignore_path}","{docname}");'
             "});"
             "</script>"
         )

--- a/jupyterlite_sphinx/jupyterlite_sphinx.py
+++ b/jupyterlite_sphinx/jupyterlite_sphinx.py
@@ -535,7 +535,7 @@ class TryExamplesDirective(SphinxDirective):
         script_html = (
             "<script>"
             'document.addEventListener("DOMContentLoaded", function() {'
-            f'window.loadTryExamplesConfig("{config_path}","{docname}");'
+            f'window.loadTryExamplesConfig("{config_path}");'
             "});"
             "</script>"
         )

--- a/jupyterlite_sphinx/jupyterlite_sphinx.py
+++ b/jupyterlite_sphinx/jupyterlite_sphinx.py
@@ -530,7 +530,18 @@ class TryExamplesDirective(SphinxDirective):
             "", f"<style>{complete_button_css}</style>", format="html"
         )
 
-        return [content_container_node, notebook_container, style_tag]
+        # For disabling interactive examples without rebuilding. Check for
+        # .disable_try_examples file and hide button if it is present.
+        script_html = (
+            "<script>"
+            'document.addEventListener("DOMContentLoaded", function() {'
+            f'    window.checkDisableTryExamples("{relative_path_to_root}");'
+            "});"
+            "</script>"
+        )
+        script_node = nodes.raw("", script_html, format="html")
+
+        return [content_container_node, notebook_container, style_tag, script_node]
 
 
 def _process_docstring_examples(app, docname, source):

--- a/jupyterlite_sphinx/jupyterlite_sphinx.py
+++ b/jupyterlite_sphinx/jupyterlite_sphinx.py
@@ -530,13 +530,12 @@ class TryExamplesDirective(SphinxDirective):
             "", f"<style>{complete_button_css}</style>", format="html"
         )
 
-        # For disabling interactive examples without rebuilding. Check for
-        # .try_examples_ignore file and hide button if it is present.
-        ignore_path = os.path.join(relative_path_to_root, ".try_examples_ignore.json")
+        # Search cnofig file allowing for config changes without rebuilding docs.
+        config_path = os.path.join(relative_path_to_root, ".try_examples.json")
         script_html = (
             "<script>"
             'document.addEventListener("DOMContentLoaded", function() {'
-            f'window.checkTryExamplesIgnore("{ignore_path}","{docname}");'
+            f'window.loadTryExamplesConfig("{config_path}","{docname}");'
             "});"
             "</script>"
         )


### PR DESCRIPTION
This PR makes it so if a file entitled `.disable_try_examples` is added to the root level of the *deployed* documentation's *build* directory, "try examples" buttons will be hidden at page load time, effectively disabling interactive examples without requiring a documentation rebuild.

A Javascript function checks at page load for the presence of the file, and if so, hides the buttons.

In https://github.com/scipy/scipy/issues/19729#issuecomment-1875437428, @rgommers noted that it would be good to be able to disable the interactive examples without requiring a rebuild of the documentation. This is particularly helpful for SciPy with its long documentation build and deployment times.

![image](https://github.com/jupyterlite/jupyterlite-sphinx/assets/1953382/8b21444b-1437-4b06-9884-3ef754fbb545)