### PR TITLE
Add processing of literal blocks in try examples directive

### DIFF
--- a/jupyterlite_sphinx/_try_examples.py
+++ b/jupyterlite_sphinx/_try_examples.py
@@ -226,7 +226,7 @@ def _process_literal_blocks(md_text):
         indent_level = len(line) - len(line.lstrip())
 
         if in_literal_block and (indent_level > 0 or line.strip() == ""):
-                literal_block_accumulator.append(line.lstrip())
+            literal_block_accumulator.append(line.lstrip())
         elif in_literal_block:
             new_lines.extend(["```"] + literal_block_accumulator + ["```"])
             literal_block_accumulator = []

--- a/jupyterlite_sphinx/_try_examples.py
+++ b/jupyterlite_sphinx/_try_examples.py
@@ -226,18 +226,35 @@ def _process_literal_blocks(md_text):
         indent_level = len(line) - len(line.lstrip())
 
         if in_literal_block and (indent_level > 0 or line.strip() == ""):
-            literal_block_accumulator.append(line)
+                literal_block_accumulator.append(line.lstrip())
         elif in_literal_block:
-            new_lines.extend(["```"] + literal_block_accumulator + ["```", line])
+            new_lines.extend(["```"] + literal_block_accumulator + ["```"])
             literal_block_accumulator = []
-            in_literal_block = False
-        elif line.endswith("::"):
-            in_literal_block = True
-            new_lines.append(line[:-2])
+            if line.endswith("::"):
+                # If the line endswith ::, a new literal block is starting.
+                line = line[:-2]  # Strip off the :: from the end
+                if not line:
+                    # If the line contains only ::, we ignore it.
+                    continue
+            else:
+                # Only set in_literal_block to False if not starting new
+                # literal block.
+                in_literal_block = False
+            # We've appended the entire literal block which just ended, but
+            # still need to append the current line.
+            new_lines.append(line)
         else:
+            if line.endswith("::"):
+                # A literal block is starting.
+                in_literal_block = True
+                line = line[:-2]
+                if not line:
+                    # As above, if the line contains only ::, ignore it.
+                    continue
             new_lines.append(line)
 
     if literal_block_accumulator:
+        # Handle case where a literal block ends the markdown cell.
         new_lines.extend(["```"] + literal_block_accumulator + ["```"])
 
     return "\n".join(new_lines)


### PR DESCRIPTION
This PR adds support for processing [literal blocks](https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html#literal-blocks) when converting RST to notebooks in the `TryExamplesDirective`. I noticed these weren't being handled correctly while going over locally built SciPy docs carefully in preparation for submitting a PR to SciPy. Screenshot below of what can go wrong when literal blocks aren't handled correctly. I'll post a link to this example after this fix is in once it finishes building and is deployed.

![image](https://github.com/jupyterlite/jupyterlite-sphinx/assets/1953382/1345d0e5-52b0-4513-b5a1-a35c1e729e7d)
