### PR TITLE
Suggestion: Add pre-commit to format js and css files.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,7 @@
+repos:
+- repo: https://github.com/pre-commit/mirrors-prettier
+  rev: 'f12edd9'  # Use the sha / tag you want to point at
+  hooks:
+  - id: prettier
+    types_or: [css, javascript]
+


### PR DESCRIPTION
I don't believe most of us know the current conventions and have the tooling installed. So it might be a good thing to have a consistent style.

If we do this we can also add pre-commit-ci so that PR are automatically updated. I'm generally not a fan of pre-commit hooks in general and pre commit-ci as it either can take forcer before you can already commit, or also when CI push on the PR, prevent pushing before pulling which can be annoying for contributor. So either choice is good for me.