### PR TITLE
Update to `jupyterlite-xeus`

### DIFF
--- a/dev-environment.yml
+++ b/dev-environment.yml
@@ -5,13 +5,13 @@ dependencies:
     - pip
     - jupyter_server
     - jupyterlab_server
-    - jupyterlite-xeus-python >=0.9.7,<0.10.0
+    - jupyterlite-xeus >=0.1.8,<0.2..0
     - jupyterlite-core >=0.2,<0.3
     - pydata-sphinx-theme
     - myst-parser
     - docutils
     - sphinx
     - black
+    - voici
     - pip:
         - .
-        - voici

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -23,11 +23,11 @@ jupyterlite_dir = "/path/to/your/lite/dir"
 
 ## Pre-installed packages
 
-In order to have Python packages pre-installed in the kernel environment, you can use [jupyterlite-xeus-python](https://xeus-python-kernel.readthedocs.io).
+In order to have Python packages pre-installed in the kernel environment, you can use [jupyterlite-xeus](https://jupyterlite-xeus.readthedocs.io), with the `xeus-python` kernel.
 
-You would need `jupyterlite-xeus-python` installed in your docs build environment.
+You would need `jupyterlite-xeus` installed in your docs build environment.
 
-You can pre-install packages by adding an `environment.yml` file in the docs directory, this file will be found automatically by xeus-python which will pre-build the environment when running the jupyter lite build.
+You can pre-install packages by adding an `environment.yml` file in the docs directory, with `xeus-python` defined as one of the dependencies. It will pre-build the environment when running the `jupyter lite build`.
 
 Furthermore, this automatically installs any labextension that it founds, for example installing ipyleaflet will make ipyleaflet work without the need to manually install the jupyter-leaflet labextension.
 

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -1,8 +1,9 @@
 name: jupyterlite-sphinx
 channels:
   - https://repo.mamba.pm/emscripten-forge
-  - https://repo.mamba.pm/conda-forge
+  - conda-forge
 dependencies:
   - pandas
   - matplotlib
   - bqplot
+  - xeus-python

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -30,13 +30,13 @@ JupyterLite should automatically show up in your built online documentation. To 
 
 ````{note}
 By default `jupyterlite-sphinx` does not install a Python kernel.
-If you would like have a Python kernel available in your docs you can install either `jupyterlite-pyodide-kernel` or `jupyterlite-xeus-python` with `pip`:
+If you would like have a Python kernel available in your docs you can install either `jupyterlite-pyodide-kernel` or `jupyterlite-xeus` with `pip`:
 
 ```shell
 # to install the Python kernel based on Pyodide
 pip install jupyterlite-pyodide-kernel
 
-# to install the Python kernel based on Xeus Python
-pip install jupyterlite-xeus-python
+# to load Xeus-based kernels
+pip install jupyterlite-xeus
 ```
 ````

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dev = [
 docs = [
     "myst_parser",
     "pydata-sphinx-theme",
-    "jupyterlite-xeus-python>=0.9.0,<0.10.0",
+    "jupyterlite-xeus>=0.1.8,<0.2.0",
 ]
 
 [tool.hatch.version]


### PR DESCRIPTION
`jupyterlite-xeus` is the new way for loading xeus kernels: https://jupyterlite-xeus.readthedocs.io/en/latest/

`jupyterlite-xeus-python` is now archived: https://github.com/jupyterlite/xeus-python-kernel

We should reflect that in the documentation.