### PR TITLE
Fix incorrect math processing

### DIFF
--- a/jupyterlite_sphinx/_try_examples.py
+++ b/jupyterlite_sphinx/_try_examples.py
@@ -133,8 +133,8 @@ def _append_code_cell_and_clear_lines(code_lines, output_lines, notebook):
 def _append_markdown_cell_and_clear_lines(markdown_lines, notebook):
     """Append new markdown cell to notebook, clearing lines."""
     markdown_text = "\n".join(markdown_lines)
-    markdown_text = _process_literal_blocks(markdown_text)
     markdown_text = _process_latex(markdown_text)
+    markdown_text = _process_literal_blocks(markdown_text)
     markdown_text = _strip_ref_identifiers(markdown_text)
     markdown_text = _convert_links(markdown_text)
     notebook.cells.append(new_markdown_cell(markdown_text))


### PR DESCRIPTION
Closes #136

This PR is an attempt to fix the incorrect math processing noted by @Carreau in #136.. It seems like the problem was introduced in https://github.com/jupyterlite/jupyterlite-sphinx/pull/134 which added handling for literal blocks. Processing `.. math::` blocks before literal blocks appears to fix the problem.

I'll build SciPy's documentation against this PR and check if there are any unintended consequences.