### PR TITLE
ENH: Add metadata for parallel_read_safe = True

### DIFF
--- a/jupyterlite_sphinx/jupyterlite_sphinx.py
+++ b/jupyterlite_sphinx/jupyterlite_sphinx.py
@@ -686,6 +686,8 @@ def setup(app):
     if try_examples_config_path.exists():
         copy_asset(str(try_examples_config_path), app.outdir)
 
+    return {"parallel_read_safe": True}
+
 
 def search_params_parser(search_params: str) -> str:
     pattern = re.compile(r"^\[(?:\s*[\"']{1}([^=\s\,&=\?\/]+)[\"']{1}\s*\,?)+\]$")


### PR DESCRIPTION
Closes #146 

This PR adds `return {"parallel_read_safe": True}` to `setup` in `jupyterlite_sphinx.py`, marking `jupyterlite_sphinx` as parallel read safe in the metadata. 

Without this, Sphinx forces a serial read

```
WARNING: the jupyterlite_sphinx extension does not declare if it is safe for parallel reading,
assuming it isn't - please ask the extension author to check and make it explicit
WARNING: doing serial read
```

I've determined that the extension is parallel read safe. I think the only point of contention is the use of `self.env.temp_data` seen below, to avoid regenerating notebooks if a docstring is processed multiple times. 

https://github.com/jupyterlite/jupyterlite-sphinx/blob/09be95849eaf7bba1287fc95e56c49360526ad40/jupyterlite_sphinx/jupyterlite_sphinx.py#L375-L381

and later on

https://github.com/jupyterlite/jupyterlite-sphinx/blob/09be95849eaf7bba1287fc95e56c49360526ad40/jupyterlite_sphinx/jupyterlite_sphinx.py#L408-L409

Since the keys in the dictionary are unique per appearance of the directive, and the only operations are setting for a key if the key doesn't exist, or checking if the key is in the dictionary, parallel reads should have no impact. I've tested this building SciPy's documentation with parallel reading, and found no issues.