### PR TITLE
fix: Correct syntax in jupyter lite command list

### DIFF
--- a/jupyterlite_sphinx/jupyterlite_sphinx.py
+++ b/jupyterlite_sphinx/jupyterlite_sphinx.py
@@ -584,7 +584,8 @@ def jupyterlite_build(app: Sphinx, error):
             for c in (
                 "jupyter",
                 "lite",
-                "doit" "build",
+                "doit",
+                "build",
                 "--debug" if jupyterlite_debug else None,
                 *config,
                 *contents,
@@ -597,7 +598,6 @@ def jupyterlite_build(app: Sphinx, error):
                 jupyterlite_dir,
                 "--log-level" if jupyterlite_log_level is not None else None,
                 jupyterlite_log_level,
-                "--",
                 "--verbosity" if jupyterlite_verbosity else None,
                 jupyterlite_verbosity,
                 "--reporter" if jupyterlite_reporter else None,


### PR DESCRIPTION
Amends PR #150 

* Add missing comma between commands.
* Removes dangling '--' that does not connect additional extra commands.

These changes unbreak https://github.com/scikit-hep/pyhf/pull/2458, and so should be minimally sufficient, though additional tests should be applied.

Tagging @steppi and @Carreau for review.