### PR TITLE
Give a pragmatic solution to suppressing noisy output

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -67,10 +67,11 @@ jupyterlite_bind_ipynb_suffix = False
 ### Suppressing jupyterlite logging
 
 `jupyterlite` can produce large amounts of output to the terminal when docs are building.
-To silence this output, you can set
+By default, this output is silenced, but will still be printed if the invocation of
+`jupyterlite build` fails. To unsilence this output, set
 
 ```python
-jupyterlite_silence = True
+jupyterlite_silence = False
 ```
 
-in your `conf.py`.
+in your Sphinx `conf.py`.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -64,23 +64,13 @@ You can disable this behavior by setting the following config:
 jupyterlite_bind_ipynb_suffix = False
 ```
 
+### Suppressing jupyterlite logging
 
-## Build logging levels
+`jupyterlite` can produce large amounts of output to the terminal when docs are building.
+To silence this output, you can set
 
-Jupyterlite-sphinx exposes jupyterlite debug and logging flags thought the
-following configuration options.
+```python
+jupyterlite_silence = True
+```
 
-
- - `jupyterlite_debug`, boolean (`False`|`True`), passes the `--debug` flag  to
-   `jupyterlite build`
-
-It also has the following configuration options:
-
- - `jupyterlite_log_level`, a `str` (defaults to `"WARN"`) or `None`
- - `jupyterlite_verbosity`, a `str` (defaults to `"0"`) or `None`
- - `jupyterlite_reporter`, a `str` (defaults to `"zero"`) or `None`
-
-Jupyterlite-sphinx uses low verbosity by default. Setting these parameters to `None` restores the `jupyterlite build` defaults.
-
-See the `jupyterlite build` documentation for info on `log-level`. `verbosity` and `reporter` control the configuration
-of [doit](https://smarie.github.io/python-doit-api/api_reference/), which is used internally in `jupyterlite`.
+in your `conf.py`.

--- a/jupyterlite_sphinx/jupyterlite_sphinx.py
+++ b/jupyterlite_sphinx/jupyterlite_sphinx.py
@@ -641,7 +641,7 @@ def setup(app):
     app.add_config_value("jupyterlite_dir", str(app.srcdir), rebuild="html")
     app.add_config_value("jupyterlite_contents", None, rebuild="html")
     app.add_config_value("jupyterlite_bind_ipynb_suffix", True, rebuild="html")
-    app.add_config_value("jupyterlite_silence", False, rebuild=True)
+    app.add_config_value("jupyterlite_silence", True, rebuild=True)
 
     app.add_config_value("global_enable_try_examples", default=False, rebuild=True)
     app.add_config_value("try_examples_global_theme", default=None, rebuild=True)

--- a/jupyterlite_sphinx/jupyterlite_sphinx.py
+++ b/jupyterlite_sphinx/jupyterlite_sphinx.py
@@ -548,11 +548,6 @@ def jupyterlite_build(app: Sphinx, error):
 
         jupyterlite_dir = str(app.env.config.jupyterlite_dir)
 
-        jupyterlite_debug = app.env.config.jupyterlite_debug
-        jupyterlite_log_level = app.env.config.jupyterlite_log_level
-        jupyterlite_verbosity = app.env.config.jupyterlite_verbosity
-        jupyterlite_reporter = app.env.config.jupyterlite_reporter
-
         config = []
         if jupyterlite_config:
             config = ["--config", jupyterlite_config]
@@ -580,37 +575,30 @@ def jupyterlite_build(app: Sphinx, error):
             apps_option.extend(["--apps", "voici"])
 
         command = [
-            c
-            for c in (
-                "jupyter",
-                "lite",
-                "doit" "build",
-                "--debug" if jupyterlite_debug else None,
-                *config,
-                *contents,
-                "--contents",
-                os.path.join(app.srcdir, CONTENT_DIR),
-                "--output-dir",
-                os.path.join(app.outdir, JUPYTERLITE_DIR),
-                *apps_option,
-                "--lite-dir",
-                jupyterlite_dir,
-                "--log-level" if jupyterlite_log_level is not None else None,
-                jupyterlite_log_level,
-                "--",
-                "--verbosity" if jupyterlite_verbosity else None,
-                jupyterlite_verbosity,
-                "--reporter" if jupyterlite_reporter else None,
-                jupyterlite_reporter,
-            )
-            if c is not None
+            "jupyter",
+            "lite",
+            "build",
+            "--debug",
+            *config,
+            *contents,
+            "--contents",
+            os.path.join(app.srcdir, CONTENT_DIR),
+            "--output-dir",
+            os.path.join(app.outdir, JUPYTERLITE_DIR),
+            *apps_option,
+            "--lite-dir",
+            jupyterlite_dir,
         ]
 
         assert all(
             [isinstance(s, str) for s in command]
         ), f"Expected all commands arguments to be a str, got {command}"
 
-        subprocess.run(command, cwd=app.srcdir, check=True)
+        kwargs = {"cwd": app.srcdir, "check": True}
+        if app.env.config.jupyterlite_silence:
+            kwargs["stdout"] = subprocess.DEVNULL
+            kwargs["stderr"] = subprocess.DEVNULL
+        subprocess.run(command, **kwargs)
 
         print("[jupyterlite-sphinx] JupyterLite build done")
 
@@ -635,12 +623,7 @@ def setup(app):
     app.add_config_value("jupyterlite_dir", str(app.srcdir), rebuild="html")
     app.add_config_value("jupyterlite_contents", None, rebuild="html")
     app.add_config_value("jupyterlite_bind_ipynb_suffix", True, rebuild="html")
-
-    # JLite debug configuration options
-    app.add_config_value("jupyterlite_debug", False, rebuild="html")
-    app.add_config_value("jupyterlite_log_level", "WARN", rebuild="html")
-    app.add_config_value("jupyterlite_verbosity", "0", rebuild="html")
-    app.add_config_value("jupyterlite_reporter", "zero", rebuild="html")
+    app.add_config_value("jupyterlite_silence", False, rebuild=True)
 
     app.add_config_value("global_enable_try_examples", default=False, rebuild=True)
     app.add_config_value("try_examples_global_theme", default=None, rebuild=True)


### PR DESCRIPTION
This PR replaces the broken means of suppressing noisy output from #150 with a pragmatic hack. (Note that although @Carreau submitted #150, I was the one who came up with this broken solution, and he was only implementing my idea).

The pragmatic hack I've made is to offer an option `jupyterlite_silence` in `config.py`. Setting this to `True` causes the `stderr` and `stout` from the call to `jupyterlite build` to be directed to `dev/null`. I've verified that this works for suppressing output, and that the notebooks still work. I have not made `jupyterlite_silence=True` the default because it's a drastic step which suppresses even warnings and errors.

I think it's reasonable to go with this hack, at least for the time being, until the necessary changes can be made in `jupyterlite`  removing unguarded `print` statements and making `doit` for tasks configurable.

Many apologies for jumping the gun and making a broken release. I will be sure to learn my lesson from this. I will need help revoking the bad release from PyPI.  

cc @Carreau, @martinRenou, @jtpio @matthewfeickert