### PR TITLE
Raise informative error message when building man on older sphinx

### DIFF
--- a/jupyterlite_sphinx/jupyterlite_sphinx.py
+++ b/jupyterlite_sphinx/jupyterlite_sphinx.py
@@ -135,6 +135,13 @@ class _LiteIframe(_PromptedIframe):
 
         iframe_src = f'{prefix}/{app_path}{f"?{options}" if options else ""}'
 
+        if "iframe_src" in attributes:
+            if attributes["iframe_src"] != iframe_src:
+                raise ValueError(
+                    f'Two different values of iframe_src {attributes["iframe_src"]=},{iframe_src=}, try upgrading sphinx to v 7.2.0 or more recent'
+                )
+            del attributes["iframe_src"]
+
         super().__init__(rawsource, *children, iframe_src=iframe_src, **attributes)
 
 


### PR DESCRIPTION
This will make the case of building manpages with earlier sphinx fail with an informative error message

```
ValueError: Two different values of iframe_src attributes["iframe_src"]='lite/repl/index.html?kernel=xeus-python&toolbar=0&theme=JupyterLab%20Light&code=print%28%22Hello%20from%20a%20JupyterLite%20console%21%22%29',iframe_src='lite/repl/index.html', try upgrading sphinx to v 7.2.0 or more recent
```

Closes #117

As noted in the issue, we could pin sphinx to >7.2, but is it really necessary if it only affects man pages ?