### PR TITLE
Allow usage of global configuration values for `TryExamples` directive if provided by user

### DIFF
--- a/docs/directives/try_examples.md
+++ b/docs/directives/try_examples.md
@@ -117,7 +117,7 @@ positioning of the button. The css for the example above is
 
 
 The `try_examples` directive has options
-* `:height:` To set a specific value for the height of the [iframe](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe) containing the embeddednotebook.
+* `:height:` To set a specific value for the height of the [iframe](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe) containing the embedded notebook.
 * `:button_text` To customize the text of the button that replaces the rendered examples with an embedded notebook.
 * `:theme:` This works the same as for the other JupyterLite-Sphinx directives.
 * `:example_class:` An html class to attach to the outer container for the rendered

--- a/docs/directives/try_examples.md
+++ b/docs/directives/try_examples.md
@@ -205,9 +205,8 @@ allowing for specification of examples sections which should not be made interac
 
 The button text, theme, and warning text can be set globally with the config variables
 `try_examples_global_button_text`, `try_examples_global_theme`, and `try_examples_global_warning_text` in `conf.py`;
-and these apply both to automatically inserted directives and to manually inserted ones. The
-priority of these global settings is lower than that of the specific options set for a manually
-inserted directive, which will override the global settings on a per-directive basis.
+these apply both to automatically and manually inserted directives. Options set explicitly in a directive will
+override the global configuration.
 
 ```python
 global_enable_try_examples = True

--- a/docs/directives/try_examples.md
+++ b/docs/directives/try_examples.md
@@ -118,13 +118,14 @@ positioning of the button. The css for the example above is
 
 The `try_examples` directive has these options:
 
-* `:height:` To set a specific value for the height of the [iframe](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe) containing the embeddednotebook.
+* `:height:` To set a specific value for the height of the [iframe](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe) containing the embedded notebook.
 * `:button_text` To customize the text of the button that replaces the rendered examples with an embedded notebook. The default value is `"Try it with JupyterLite!"`, or the value of the global configuration variable `try_examples_global_button_text` if it is set in `conf.py`.
 * `:theme:` This works the same as for the other JupyterLite-Sphinx directives.
 * `:example_class:` An html class to attach to the outer container for the rendered
 examples content and embedded notebook. This can be used in a custom css file to allow
 for more precise customization, eg. different button styles across different examples.
-* `:warning_text:` Prepend a markdown cell to the notebook containing this text, styled to make it clear this is intended as a warning.
+The default value is the value of the global configuration variable `try_examples_global_theme`, if it is set in `conf.py`.
+* `:warning_text:` Prepend a markdown cell to the notebook containing this text, styled to make it clear this is intended as a warning. The default value is the value of the global configuration variable `try_examples_global_warning_text` if it is set in `conf.py`, otherwise no warning text is added.
 
 Here's an example with some options set
 

--- a/docs/directives/try_examples.md
+++ b/docs/directives/try_examples.md
@@ -19,7 +19,7 @@ Examples
 .. try_examples::
 
     Doctest examples sections are parsed and converted to notebooks. Blocks of text
-    like this become Markdown cells. Code blocks begin with ``>>>``. Contiguous blocks
+    like this become markdown cells. Codeblocks begin with ``>>>``. Contiguous blocks
     of code are combined into a single code cell.
 
     >>> x = 2
@@ -116,16 +116,14 @@ positioning of the button. The css for the example above is
 ```
 
 
-The `try_examples` directive has these options:
-
-* `:height:` To set a specific value for the height of the [iframe](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe) containing the embedded notebook.
-* `:button_text` To customize the text of the button that replaces the rendered examples with an embedded notebook. The default value is `"Try it with JupyterLite!"`, or the value of the global configuration variable `try_examples_global_button_text` if it is set in `conf.py`.
+The `try_examples` directive has options
+* `:height:` To set a specific value for the height of the [iframe](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe) containing the embeddednotebook.
+* `:button_text` To customize the text of the button that replaces the rendered examples with an embedded notebook.
 * `:theme:` This works the same as for the other JupyterLite-Sphinx directives.
 * `:example_class:` An html class to attach to the outer container for the rendered
 examples content and embedded notebook. This can be used in a custom css file to allow
 for more precise customization, eg. different button styles across different examples.
-The default value is the value of the global configuration variable `try_examples_global_theme`, if it is set in `conf.py`.
-* `:warning_text:` Prepend a markdown cell to the notebook containing this text, styled to make it clear this is intended as a warning. The default value is the value of the global configuration variable `try_examples_global_warning_text` if it is set in `conf.py`, otherwise no warning text is added.
+* `:warning_text:` Prepend a markdown cell to the notebook containing this text, styled to make it clear this is intended as a warning.
 
 Here's an example with some options set
 
@@ -206,7 +204,10 @@ allowing for specification of examples sections which should not be made interac
 
 
 The button text, theme, and warning text can be set globally with the config variables
-`try_examples_global_button_text`, `try_examples_global_theme`, and `try_examples_global_warning_text`.
+`try_examples_global_button_text`, `try_examples_global_theme`, and `try_examples_global_warning_text` in `conf.py`;
+and these apply both to automatically inserted directives and to manually inserted ones. The
+priority of these global settings is lower than that of the specific options set for a manually
+inserted directive, which will override the global settings on a per-directive basis.
 
 ```python
 global_enable_try_examples = True
@@ -215,7 +216,7 @@ try_examples_global_height = "200px"
 try_examples_global_warning_text = "Interactive examples are experimental and may not always work as expected."
 ```
 
-There is no option to set a global specific height because the proper height
+However, there is no option to set a global specific height because the proper height
 should depend on the size of the examples content. Again, the default height of
 the embedded notebook's iframe container matches the height of the associated
 rendered doctest example so that it takes up the same amount of space on the

--- a/docs/directives/try_examples.md
+++ b/docs/directives/try_examples.md
@@ -19,7 +19,7 @@ Examples
 .. try_examples::
 
     Doctest examples sections are parsed and converted to notebooks. Blocks of text
-    like this become markdown cells. Codeblocks begin with ``>>>``. Contiguous blocks
+    like this become Markdown cells. Code blocks begin with ``>>>``. Contiguous blocks
     of code are combined into a single code cell.
 
     >>> x = 2
@@ -116,9 +116,10 @@ positioning of the button. The css for the example above is
 ```
 
 
-The `try_examples` directive has options
+The `try_examples` directive has these options:
+
 * `:height:` To set a specific value for the height of the [iframe](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe) containing the embeddednotebook.
-* `:button_text` To customize the text of the button that replaces the rendered examples with an embedded notebook.
+* `:button_text` To customize the text of the button that replaces the rendered examples with an embedded notebook. The default value is `"Try it with JupyterLite!"`, or the value of the global configuration variable `try_examples_global_button_text` if it is set in `conf.py`.
 * `:theme:` This works the same as for the other JupyterLite-Sphinx directives.
 * `:example_class:` An html class to attach to the outer container for the rendered
 examples content and embedded notebook. This can be used in a custom css file to allow

--- a/docs/directives/try_examples.md
+++ b/docs/directives/try_examples.md
@@ -216,7 +216,7 @@ try_examples_global_height = "200px"
 try_examples_global_warning_text = "Interactive examples are experimental and may not always work as expected."
 ```
 
-However, there is no option to set a global specific height because the proper height
+There is no option to set a global specific height because the proper height
 should depend on the size of the examples content. Again, the default height of
 the embedded notebook's iframe container matches the height of the associated
 rendered doctest example so that it takes up the same amount of space on the

--- a/jupyterlite_sphinx/jupyterlite_sphinx.py
+++ b/jupyterlite_sphinx/jupyterlite_sphinx.py
@@ -393,10 +393,9 @@ class TryExamplesDirective(SphinxDirective):
             default_button_text = "Try it with JupyterLite!"
         button_text = self.options.pop("button_text", default_button_text)
 
-        # Use warning_text from try_examples_global_warning_text if not provided
+        # Use warning_text from try_examples_global_warning_text by default. If
+        # it is not provided, don't show any warning text
         default_warning_text = self.env.config.try_examples_global_warning_text
-        if default_warning_text is None:
-            default_warning_text = "Interactive examples are experimental and may not always work as expected."
         warning_text = self.options.pop("warning_text", default_warning_text)
 
         # Keep height as is because it is specific to the example being embedded

--- a/jupyterlite_sphinx/jupyterlite_sphinx.py
+++ b/jupyterlite_sphinx/jupyterlite_sphinx.py
@@ -404,8 +404,7 @@ class TryExamplesDirective(SphinxDirective):
             default_example_class = ""
         example_class = self.options.pop("example_class", default_example_class)
 
-        # No global option for height is available, so we use the one provided
-        # manually in the directive.
+        # A global height cannot be set in conf.py
         height = self.options.pop("height", None)
 
         # We need to get the relative path back to the documentation root from

--- a/jupyterlite_sphinx/jupyterlite_sphinx.py
+++ b/jupyterlite_sphinx/jupyterlite_sphinx.py
@@ -387,26 +387,26 @@ class TryExamplesDirective(SphinxDirective):
             directive_key
         )
 
-        # Use button_text from try_examples_global_button_text if not provided
+        # Use global configuration values from conf.py in manually inserted directives
+        # if they are provided and the user has not specified a config value in the
+        # directive itself.
+
         default_button_text = self.env.config.try_examples_global_button_text
         if default_button_text is None:
             default_button_text = "Try it with JupyterLite!"
         button_text = self.options.pop("button_text", default_button_text)
 
-        # Use warning_text from try_examples_global_warning_text by default. If
-        # it is not provided, don't show any warning text
         default_warning_text = self.env.config.try_examples_global_warning_text
         warning_text = self.options.pop("warning_text", default_warning_text)
 
-        # Keep height as is because it is specific to the example being embedded
-        # into the notebook
-        height = self.options.pop("height", None)
-
-        # Use example_class from try_examples_global_theme if not provided
         default_example_class = self.env.config.try_examples_global_theme
         if default_example_class is None:
             default_example_class = ""
         example_class = self.options.pop("example_class", default_example_class)
+
+        # No global option for height is available, so we use the one provided
+        # manually in the directive.
+        height = self.options.pop("height", None)
 
         # We need to get the relative path back to the documentation root from
         # whichever file the docstring content is in.

--- a/jupyterlite_sphinx/jupyterlite_sphinx.py
+++ b/jupyterlite_sphinx/jupyterlite_sphinx.py
@@ -382,14 +382,31 @@ class TryExamplesDirective(SphinxDirective):
 
         # Use button_text from try_examples_global_button_text if not provided
         if self.env.config.try_examples_global_button_text is not None:
-            button_text = self.options.pop(
+            button_text = self.options.get(
                 "button_text", self.env.config.try_examples_global_button_text
             )
         else:
             button_text = self.options.pop("button_text", "Try it with JupyterLite!")
+
+        # Use warning_text from try_examples_global_warning_text if not provided
+        if self.env.config.try_examples_global_warning_text is not None:
+            warning_text = self.options.get(
+                "warning_text", self.env.config.try_examples_global_warning_text
+            )
+        else:
+            warning_text = self.options.pop("warning_text", None)
+
+        # Keep height as is because it is specific to the example being embedded
+        # into the notebook
         height = self.options.pop("height", None)
-        example_class = self.options.pop("example_class", "")
-        warning_text = self.options.pop("warning_text", None)
+
+        # Use example_class from try_examples_global_theme if not provided
+        if self.env.config.try_examples_global_theme is not None:
+            example_class = self.options.get(
+                "example_class", self.env.config.try_examples_global_theme
+            )
+        else:
+            example_class = self.options.pop("example_class", "")
 
         # We need to get the relative path back to the documentation root from
         # whichever file the docstring content is in.

--- a/jupyterlite_sphinx/jupyterlite_sphinx.py
+++ b/jupyterlite_sphinx/jupyterlite_sphinx.py
@@ -388,32 +388,26 @@ class TryExamplesDirective(SphinxDirective):
         )
 
         # Use button_text from try_examples_global_button_text if not provided
-        if self.env.config.try_examples_global_button_text is not None:
-            button_text = self.options.get(
-                "button_text", self.env.config.try_examples_global_button_text
-            )
-        else:
-            button_text = self.options.pop("button_text", "Try it with JupyterLite!")
+        default_button_text = self.env.config.try_examples_global_button_text
+        if default_button_text is None:
+            default_button_text = "Try it with JupyterLite!"
+        button_text = self.options.pop("button_text", default_button_text)
 
         # Use warning_text from try_examples_global_warning_text if not provided
-        if self.env.config.try_examples_global_warning_text is not None:
-            warning_text = self.options.get(
-                "warning_text", self.env.config.try_examples_global_warning_text
-            )
-        else:
-            warning_text = self.options.pop("warning_text", None)
+        default_warning_text = self.env.config.try_examples_global_warning_text
+        if default_warning_text is None:
+            default_warning_text = "Interactive examples are experimental and may not always work as expected."
+        warning_text = self.options.pop("warning_text", default_warning_text)
 
         # Keep height as is because it is specific to the example being embedded
         # into the notebook
         height = self.options.pop("height", None)
 
         # Use example_class from try_examples_global_theme if not provided
-        if self.env.config.try_examples_global_theme is not None:
-            example_class = self.options.get(
-                "example_class", self.env.config.try_examples_global_theme
-            )
-        else:
-            example_class = self.options.pop("example_class", "")
+        default_example_class = self.env.config.try_examples_global_theme
+        if default_example_class is None:
+            default_example_class = ""
+        example_class = self.options.pop("example_class", default_example_class)
 
         # We need to get the relative path back to the documentation root from
         # whichever file the docstring content is in.

--- a/jupyterlite_sphinx/jupyterlite_sphinx.py
+++ b/jupyterlite_sphinx/jupyterlite_sphinx.py
@@ -380,7 +380,13 @@ class TryExamplesDirective(SphinxDirective):
             directive_key
         )
 
-        button_text = self.options.pop("button_text", "Try it with Jupyterlite!")
+        # Use button_text from try_examples_global_button_text if not provided
+        if self.env.config.try_examples_global_button_text is not None:
+            button_text = self.options.pop(
+                "button_text", self.env.config.try_examples_global_button_text
+            )
+        else:
+            button_text = self.options.pop("button_text", "Try it with JupyterLite!")
         height = self.options.pop("height", None)
         example_class = self.options.pop("example_class", "")
         warning_text = self.options.pop("warning_text", None)
@@ -604,7 +610,7 @@ def jupyterlite_build(app: Sphinx, error):
         if completed_process.returncode != 0:
             if app.env.config.jupyterlite_silence:
                 print(
-                    "`jupyterlite build` failed but it's output has been silenced."
+                    "`jupyterlite build` failed but its output has been silenced."
                     " stdout and stderr are reproduced below.\n"
                 )
                 print("stdout:", completed_process.stdout.decode())


### PR DESCRIPTION
## Description

This PR updates the `TryExamplesDirective` class to use the configuration value in `conf.py` if specified, and otherwise use the "Try it with JupyterLite" text. This way, buttons that are created manually with the

```rst
.. try_examples::
```

directive in Sphinx will receive the same configuration value, and adding a `:button_text` input across several `.. try_examples::` directives to customise the button text will now **not** be required. The `try_examples_global_button_text` string will be used by default, instead of the current `"Try it with JupyterLite!"` text.

To explain this behaviour, an additional sentence has been added to the documentation for the `TryExamples` directive page.

Closes #157 

## Footnotes

This is essentially a breaking change of sorts for dependents who are not using a custom `:button_text` input already, since it will now change the text to what they have set in `try_examples_global_button_text` (in case they have set that). But it's surely not a very big change and I would consider it as more of an enhancement (cc: @steppi)