### PR TITLE
Add the option to open JupyterLite window in new tab

### DIFF
--- a/docs/directives/jupyterlite.md
+++ b/docs/directives/jupyterlite.md
@@ -36,6 +36,18 @@ You can also pass a Notebook file to open automatically:
    :prompt_color: #00aa42
 ```
 
+If you use the `:new_tab:` option in the directive, the Notebook will be opened in a new browser tab.
+
+```rst
+.. jupyterlite:: my_notebook.ipynb
+   :new_tab: True
+```
+
+```{eval-rst}
+.. jupyterlite:: my_notebook.ipynb
+   :new_tab: True
+```
+
 The directive `search_params` allows to transfer some search parameters from the documentation URL to the Jupyterlite URL.\
 Jupyterlite will then be able to fetch these parameters from its own URL.\
 For example `:search_params: ["param1", "param2"]` will transfer the parameters *param1* and *param2*.

--- a/jupyterlite_sphinx/jupyterlite_sphinx.py
+++ b/jupyterlite_sphinx/jupyterlite_sphinx.py
@@ -128,7 +128,7 @@ class _InTab(Element):
         self.lab_src = f'{prefix}/{app_path}{f"?{options}" if options else ""}'
 
         super().__init__(
-            "",
+            rawsource,
             **attributes,
         )
 

--- a/jupyterlite_sphinx/jupyterlite_sphinx.py
+++ b/jupyterlite_sphinx/jupyterlite_sphinx.py
@@ -106,6 +106,40 @@ class _PromptedIframe(Element):
             f'width="{self["width"]}" height="{self["height"]}" class="jupyterlite_sphinx_raw_iframe"></iframe>'
         )
 
+class _InTab(Element):
+    def __init__(
+        self,
+        rawsource="",
+        *children,
+        prefix=JUPYTERLITE_DIR,
+        notebook=None,
+        lite_options={},
+        **attributes,
+    ):
+        app_path = self.lite_app
+        if notebook is not None:
+            lite_options["path"] = notebook
+            app_path = f"{self.lite_app}{self.notebooks_path}"
+
+        options = "&".join(
+            [f"{key}={quote(value)}" for key, value in lite_options.items()]
+        )
+        self.lab_src = (
+            f'{prefix}/{app_path}{f"?{options}" if options else ""}'
+        )
+
+        super().__init__(
+            "",
+            **attributes,
+        )
+
+    def html(self):
+        return (
+            '<button class="try_examples_button" '
+            f"onclick=\"window.open('{self.lab_src}')\">"
+            "Open as a notebook</button>"
+        )
+
 
 class _LiteIframe(_PromptedIframe):
     def __init__(
@@ -164,6 +198,14 @@ class JupyterLiteIframe(_LiteIframe):
     lite_app = "lab/"
     notebooks_path = ""
 
+class JupyterLiteTab(_InTab):
+    """Appended to the doctree by the JupyterliteDirective directive
+
+    Renders a button that opens a Notebook with JupyterLite in a new tab.
+    """
+
+    lite_app = "lab/"
+    notebooks_path = ""
 
 class NotebookLiteIframe(_LiteIframe):
     """Appended to the doctree by the NotebookliteDirective directive
@@ -262,6 +304,7 @@ class _LiteDirective(SphinxDirective):
         "prompt": directives.unchanged,
         "prompt_color": directives.unchanged,
         "search_params": directives.unchanged,
+        "new_tab": directives.unchanged,
     }
 
     def run(self):
@@ -272,6 +315,8 @@ class _LiteDirective(SphinxDirective):
         prompt_color = self.options.pop("prompt_color", None)
 
         search_params = search_params_parser(self.options.pop("search_params", False))
+
+        new_tab = self.options.pop("new_tab", False)
 
         source_location = os.path.dirname(self.get_source_info()[0])
 
@@ -299,6 +344,20 @@ class _LiteDirective(SphinxDirective):
         else:
             notebook_name = None
 
+        if new_tab:
+            return [
+                self.newtab_cls(
+                    prefix=prefix,
+                    notebook=notebook_name,
+                    width=width,
+                    height=height,
+                    prompt=prompt,
+                    prompt_color=prompt_color,
+                    search_params=search_params,
+                    lite_options=self.options,
+                )
+            ]
+
         return [
             self.iframe_cls(
                 prefix=prefix,
@@ -320,6 +379,7 @@ class JupyterLiteDirective(_LiteDirective):
     """
 
     iframe_cls = JupyterLiteIframe
+    newtab_cls = JupyterLiteTab
 
 
 class NotebookLiteDirective(_LiteDirective):
@@ -688,6 +748,14 @@ def setup(app):
     app.add_directive("retrolite", NotebookLiteDirective)
     app.add_node(
         JupyterLiteIframe,
+        html=(visit_element_html, None),
+        latex=(skip, None),
+        textinfo=(skip, None),
+        text=(skip, None),
+        man=(skip, None),
+    )
+    app.add_node(
+        JupyterLiteTab,
         html=(visit_element_html, None),
         latex=(skip, None),
         textinfo=(skip, None),

--- a/jupyterlite_sphinx/jupyterlite_sphinx.py
+++ b/jupyterlite_sphinx/jupyterlite_sphinx.py
@@ -106,6 +106,7 @@ class _PromptedIframe(Element):
             f'width="{self["width"]}" height="{self["height"]}" class="jupyterlite_sphinx_raw_iframe"></iframe>'
         )
 
+
 class _InTab(Element):
     def __init__(
         self,
@@ -124,9 +125,7 @@ class _InTab(Element):
         options = "&".join(
             [f"{key}={quote(value)}" for key, value in lite_options.items()]
         )
-        self.lab_src = (
-            f'{prefix}/{app_path}{f"?{options}" if options else ""}'
-        )
+        self.lab_src = f'{prefix}/{app_path}{f"?{options}" if options else ""}'
 
         super().__init__(
             "",
@@ -198,6 +197,7 @@ class JupyterLiteIframe(_LiteIframe):
     lite_app = "lab/"
     notebooks_path = ""
 
+
 class JupyterLiteTab(_InTab):
     """Appended to the doctree by the JupyterliteDirective directive
 
@@ -206,6 +206,7 @@ class JupyterLiteTab(_InTab):
 
     lite_app = "lab/"
     notebooks_path = ""
+
 
 class NotebookLiteIframe(_LiteIframe):
     """Appended to the doctree by the NotebookliteDirective directive


### PR DESCRIPTION
My use case is the following: I'd like to use the jupyterlite directive to open the **full page** I am visiting as a Jupytext notebook. This PR adds that option to the JupyterLite directive.  

Pending is finding the correct path for opening the current file __as an ipynb file__: since the source is an .md file, it will be converted into an .ipynb file at some point in the build process. For now, however, Sphinx can't process the directive since it will try to embed a link to the ipynb file before reading the current source .md file, and complain about the missing reference.

I am not sure if I am following the right path here so please let me know if I should approach this differently. 

cc @agriyakhetarpal 