### PR TITLE
Pass additional configuration options to the `jupyter lite build` command

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -6,10 +6,6 @@ extensions = [
     "myst_parser",
 ]
 
-myst_enable_extensions = [
-    "colon_fence"
-]
-
 html_theme = "pydata_sphinx_theme"
 html_logo = "_static/icon.svg"
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -11,7 +11,6 @@ html_logo = "_static/icon.svg"
 
 jupyterlite_contents = "./custom_contents"
 jupyterlite_bind_ipynb_suffix = False
-jupyterlite_silence = False
 
 master_doc = "index"
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -6,6 +6,10 @@ extensions = [
     "myst_parser",
 ]
 
+myst_enable_extensions = [
+    "colon_fence"
+]
+
 html_theme = "pydata_sphinx_theme"
 html_logo = "_static/icon.svg"
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -11,6 +11,7 @@ html_logo = "_static/icon.svg"
 
 jupyterlite_contents = "./custom_contents"
 jupyterlite_bind_ipynb_suffix = False
+jupyterlite_silence = False
 
 master_doc = "index"
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -29,9 +29,9 @@ You would need `jupyterlite-xeus` installed in your docs build environment.
 
 You can pre-install packages by adding an `environment.yml` file in the docs directory, with `xeus-python` defined as one of the dependencies. It will pre-build the environment when running the `jupyter lite build`.
 
-Furthermore, this automatically installs any labextension that it finds, for example, installing `ipyleaflet` will make `ipyleaflet` work without the need to manually install the `jupyter-leaflet` labextension.
+Furthermore, this automatically installs any labextension that it founds, for example installing ipyleaflet will make ipyleaflet work without the need to manually install the jupyter-leaflet labextension.
 
-Say you want to install NumPy, Matplotlib and ipycanvas, it can be done by creating the `environment.yml` file with the following content:
+Say you want to install NumPy, Matplotlib and ipycanvas, it can be done by creating the environment.yml file with the following content:
 
 ```yaml
 name: xeus-python-kernel
@@ -56,7 +56,7 @@ jupyterlite_config = "jupyterlite_config.json"
 ## Disable the `.ipynb` docs source binding
 
 By default, jupyterlite-sphinx binds the `.ipynb` source suffix so that it renders Notebooks included in the doctree with JupyterLite.
-This is known to bring warnings with plugins like `sphinx-gallery`, or to conflict with `nbsphinx`.
+This is known to bring warnings with plugins like sphinx-gallery, or to conflict with nbsphinx.
 
 You can disable this behavior by setting the following config:
 
@@ -64,11 +64,11 @@ You can disable this behavior by setting the following config:
 jupyterlite_bind_ipynb_suffix = False
 ```
 
-### Suppressing JupyterLite logging
+### Suppressing jupyterlite logging
 
 `jupyterlite` can produce large amounts of output to the terminal when docs are building.
 By default, this output is silenced, but will still be printed if the invocation of
-`jupyter lite build` fails. To unsilence this output, set
+`jupyterlite build` fails. To unsilence this output, set
 
 ```python
 jupyterlite_silence = False

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -82,14 +82,13 @@ You can pass additional arguments to the `jupyter lite build` command by passing
 
 ```python
 jupyterlite_build_command_options = {
-    "port": 8888,
     "XeusAddon.environment_file": "jupyterlite_environment.yml",
-    "source-date-epoch": "315532800",
+    ...
     }
 ```
 
-This will launch the JupyterLite site on port 8888, configure the `jupyterlite-xeus` kernel with a custom
-`jupyterlite_environment.yml` file, and configure the source date epoch to ensure reproducible builds.
+This will launch the JupyterLite site, configuring the `jupyterlite-xeus` kernel with a custom
+`jupyterlite_environment.yml` file.
 
 :::{attention}
 The `--contents`, `--output-dir`, and `--lite-dir` options are not supported in this scenario, as they are set by

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -90,13 +90,9 @@ jupyterlite_build_command_options = {
 This will launch the JupyterLite site, configuring the `jupyterlite-xeus` kernel with a custom
 `jupyterlite_environment.yml` file.
 
-:::{attention}
 The `--contents`, `--output-dir`, and `--lite-dir` options are not supported in this scenario, as they are set by
 the [`jupyterlite_contents`](#jupyterlite-content) and the[`jupyterlite_dir`](#jupyterlite-dir) configuration
 options, respectively, as described above.
-:::
 
-:::{seealso}
 The full list of available options can be found by running the `jupyter lite build --help-all` command. For more
 information, please visit the [JupyterLite documentation](https://jupyterlite.readthedocs.io/en/stable/reference/cli.html#usage).
-:::

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -98,6 +98,7 @@ These can instead be set with
 the [`jupyterlite_contents`](#jupyterlite-content) and the[`jupyterlite_dir`](#jupyterlite-dir) configuration
 options described above.
 
-These options take precedence over the options provided by the user such as via environment variables
-or through JSON-based configuration files.
 This is an advanced feature and users are responsible for providing sensible command line options.
+The standard precedence between `jupyter lite build` CLI options and other means of configuration apply.
+See the [jupyter lite CLI](https://jupyterlite.readthedocs.io/en/latest/reference/cli.html) documentation
+for more info.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -97,3 +97,5 @@ The options `--contents`, `--output-dir`, and `--lite-dir` cannot be passed to `
 These can instead be set with
 the [`jupyterlite_contents`](#jupyterlite-content) and the[`jupyterlite_dir`](#jupyterlite-dir) configuration
 options described above.
+
+This is an advanced feature and users are responsible for providing sensible command line options.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -78,7 +78,7 @@ in your Sphinx `conf.py`.
 
 ## Additional CLI arguments for `jupyter lite build`
 
-You can pass additional arguments to the `jupyter lite build` command by passing a dictionary of arguments to the `jupyterlite_build_command_args` configuration option, without the hyphens prepended to the keys. Here's an example:
+You can pass additional arguments to the `jupyter lite build` command by passing a dictionary of arguments to the `jupyterlite_build_command_options` configuration option, without the hyphens prepended to the keys. Here's an example:
 
 ```python
 jupyterlite_build_command_options = {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -78,21 +78,22 @@ in your Sphinx `conf.py`.
 
 ## Additional CLI arguments for `jupyter lite build`
 
-You can pass additional arguments to the `jupyter lite build` command by passing a dictionary of arguments to the `jupyterlite_build_command_options` configuration option, without the hyphens prepended to the keys. Here's an example:
+Additional arguments can be passed to the `jupyter lite build` command using the configuration
+option `jupyterlite_build_command_options` in `conf.py`. The following example shows how to
+specify an alternative location for the `xeus` kernel's `environment.yml` file as discussed
+[here](https://github.com/jupyterlite/xeus#usage).
 
 ```python
 jupyterlite_build_command_options = {
     "XeusAddon.environment_file": "jupyterlite_environment.yml",
-    ...
     }
 ```
 
-This will launch the JupyterLite site, configuring the `jupyterlite-xeus` kernel with a custom
-`jupyterlite_environment.yml` file.
+This causes the additional option `--XeusAddon.environment_file=jupyterlite_environment.yml`
+to be passed to `jupyter lite build` internally within `jupyterlite-sphinx`. Note that one
+does not include the leading dashes, `--`, in the keys.
 
-The `--contents`, `--output-dir`, and `--lite-dir` options are not supported in this scenario, as they are set by
+The options `--contents`, `--output-dir`, and `--lite-dir` cannot be passed to `jupyter lite build` in this way.
+These can instead be set with
 the [`jupyterlite_contents`](#jupyterlite-content) and the[`jupyterlite_dir`](#jupyterlite-dir) configuration
-options, respectively, as described above.
-
-The full list of available options can be found by running the `jupyter lite build --help-all` command. For more
-information, please visit the [JupyterLite documentation](https://jupyterlite.readthedocs.io/en/stable/reference/cli.html#usage).
+options described above.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -29,9 +29,9 @@ You would need `jupyterlite-xeus` installed in your docs build environment.
 
 You can pre-install packages by adding an `environment.yml` file in the docs directory, with `xeus-python` defined as one of the dependencies. It will pre-build the environment when running the `jupyter lite build`.
 
-Furthermore, this automatically installs any labextension that it founds, for example installing ipyleaflet will make ipyleaflet work without the need to manually install the jupyter-leaflet labextension.
+Furthermore, this automatically installs any labextension that it finds, for example, installing `ipyleaflet` will make `ipyleaflet` work without the need to manually install the `jupyter-leaflet` labextension.
 
-Say you want to install NumPy, Matplotlib and ipycanvas, it can be done by creating the environment.yml file with the following content:
+Say you want to install NumPy, Matplotlib and ipycanvas, it can be done by creating the `environment.yml` file with the following content:
 
 ```yaml
 name: xeus-python-kernel
@@ -56,7 +56,7 @@ jupyterlite_config = "jupyterlite_config.json"
 ## Disable the `.ipynb` docs source binding
 
 By default, jupyterlite-sphinx binds the `.ipynb` source suffix so that it renders Notebooks included in the doctree with JupyterLite.
-This is known to bring warnings with plugins like sphinx-gallery, or to conflict with nbsphinx.
+This is known to bring warnings with plugins like `sphinx-gallery`, or to conflict with `nbsphinx`.
 
 You can disable this behavior by setting the following config:
 
@@ -64,11 +64,11 @@ You can disable this behavior by setting the following config:
 jupyterlite_bind_ipynb_suffix = False
 ```
 
-### Suppressing jupyterlite logging
+### Suppressing JupyterLite logging
 
 `jupyterlite` can produce large amounts of output to the terminal when docs are building.
 By default, this output is silenced, but will still be printed if the invocation of
-`jupyterlite build` fails. To unsilence this output, set
+`jupyter lite build` fails. To unsilence this output, set
 
 ```python
 jupyterlite_silence = False

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -75,3 +75,29 @@ jupyterlite_silence = False
 ```
 
 in your Sphinx `conf.py`.
+
+## Additional CLI arguments for `jupyter lite build`
+
+You can pass additional arguments to the `jupyter lite build` command by passing a dictionary of arguments to the `jupyterlite_build_command_args` configuration option, without the hyphens prepended to the keys. Here's an example:
+
+```python
+jupyterlite_build_command_options = {
+    "port": 8888,
+    "XeusAddon.environment_file": "jupyterlite_environment.yml",
+    "source-date-epoch": "315532800",
+    }
+```
+
+This will launch the JupyterLite site on port 8888, configure the `jupyterlite-xeus` kernel with a custom
+`jupyterlite_environment.yml` file, and configure the source date epoch to ensure reproducible builds.
+
+:::{attention}
+The `--contents`, `--output-dir`, and `--lite-dir` options are not supported in this scenario, as they are set by
+the [`jupyterlite_contents`](#jupyterlite-content) and the[`jupyterlite_dir`](#jupyterlite-dir) configuration
+options, respectively, as described above.
+:::
+
+:::{seealso}
+The full list of available options can be found by running the `jupyter lite build --help-all` command. For more
+information, please visit the [JupyterLite documentation](https://jupyterlite.readthedocs.io/en/stable/reference/cli.html#usage).
+:::

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -98,4 +98,6 @@ These can instead be set with
 the [`jupyterlite_contents`](#jupyterlite-content) and the[`jupyterlite_dir`](#jupyterlite-dir) configuration
 options described above.
 
+These options take precedence over the options provided by the user such as via environment variables
+or through JSON-based configuration files.
 This is an advanced feature and users are responsible for providing sensible command line options.

--- a/jupyterlite_sphinx/jupyterlite_sphinx.py
+++ b/jupyterlite_sphinx/jupyterlite_sphinx.py
@@ -632,7 +632,7 @@ def jupyterlite_build(app: Sphinx, error):
                 https://jupyterlite-sphinx.readthedocs.io/en/stable/configuration.html
                 """
                     raise ValueError(jupyterlite_command_error_message)
-                command.extend([f"--{key}", value])
+                command.extend([f"--{key}", str(value)])
 
         assert all(
             [isinstance(s, str) for s in command]

--- a/jupyterlite_sphinx/jupyterlite_sphinx.py
+++ b/jupyterlite_sphinx/jupyterlite_sphinx.py
@@ -631,8 +631,8 @@ def jupyterlite_build(app: Sphinx, error):
                 command and refer to the documentation for jupyterlite-sphinx:
                 https://jupyterlite-sphinx.readthedocs.io/en/stable/configuration.html
                 """
-                    raise ValueError(jupyterlite_command_error_message.format(key=key))
-                command.extend([f"--{key.replace('_', '-')}", value])
+                    raise ValueError(jupyterlite_command_error_message)
+                command.extend([f"--{key}", value])
 
         assert all(
             [isinstance(s, str) for s in command]

--- a/jupyterlite_sphinx/jupyterlite_sphinx.py
+++ b/jupyterlite_sphinx/jupyterlite_sphinx.py
@@ -623,11 +623,11 @@ def jupyterlite_build(app: Sphinx, error):
                 # Check for conflicting options from the default command we use
                 # while building. We don't want to allow these to be overridden
                 # unless they are explicitly set through Sphinx config.
-                if key in ["contents", "output_dir", "lite_dir"]:
+                if key in ["contents", "output-dir", "lite-dir"]:
                     jupyterlite_command_error_message = f"""
                     Additional option, {key}, passed to `jupyter lite build` through
                     `jupyterlite_build_command_options` in conf.py is already an existing
-                    option.  "contents", "output_dir", and "lite_dir" can be configured in
+                    option. "contents", "output_dir", and "lite_dir" can be configured in
                     conf.py as described in the jupyterlite-sphinx documentation:
                     https://jupyterlite-sphinx.readthedocs.io/en/stable/configuration.html
                     """

--- a/jupyterlite_sphinx/jupyterlite_sphinx.py
+++ b/jupyterlite_sphinx/jupyterlite_sphinx.py
@@ -624,13 +624,13 @@ def jupyterlite_build(app: Sphinx, error):
                 # while building. We don't want to allow these to be overridden
                 # unless they are explicitly set through Sphinx config.
                 if key in ["contents", "output_dir", "lite_dir"]:
-                    jupyterlite_command_error_message = """
-                Cannot use [contents, output_dir, lite_dir] in jupyterlite_build_command_options.
-                Please use the corresponding option directly in conf.py.
-                For a list of available options, run the 'jupyter lite build --help-all'
-                command and refer to the documentation for jupyterlite-sphinx:
-                https://jupyterlite-sphinx.readthedocs.io/en/stable/configuration.html
-                """
+                    jupyterlite_command_error_message = f"""
+                    Additional option, {key}, passed to `jupyter lite build` through
+                    `jupyterlite_build_command_options` in conf.py is already an existing
+                    option.  "contents", "output_dir", and "lite_dir" can be configured in
+                    conf.py as described in the jupyterlite-sphinx documentation:
+                    https://jupyterlite-sphinx.readthedocs.io/en/stable/configuration.html
+                    """
                     raise ValueError(jupyterlite_command_error_message)
                 command.extend([f"--{key}", str(value)])
 

--- a/jupyterlite_sphinx/jupyterlite_sphinx.py
+++ b/jupyterlite_sphinx/jupyterlite_sphinx.py
@@ -631,7 +631,7 @@ def jupyterlite_build(app: Sphinx, error):
                     conf.py as described in the jupyterlite-sphinx documentation:
                     https://jupyterlite-sphinx.readthedocs.io/en/stable/configuration.html
                     """
-                    raise ValueError(jupyterlite_command_error_message)
+                    raise RuntimeError(jupyterlite_command_error_message)
                 command.extend([f"--{key}", str(value)])
 
         assert all(


### PR DESCRIPTION
## Description

This PR closes #168. It aims to implement additional options from the JupyterLite CLI, i.e., the `jupyter lite build` command that is currently wrapped in a subprocess call inside a Sphinx app. This enables the use of, say, custom environments from a file as requested in https://github.com/jupyterlite/jupyterlite-sphinx/issues/168#issuecomment-2079472156, allowing overrides in case of conflicts where `environment.yml` might refer to a file that is not being used for `jupyterlite-sphinx` but for setting up general environments with `mamba` or `conda`.

## Changes made

- Added `jupyterlite_build_command_options` as a configuration option to allow power users of `jupyterlite-sphinx` to customise their JupyterLite build procedure with a dictionary of options.

## Task list

- [x] Implement ways to add options from https://jupyterlite.readthedocs.io/en/latest/reference/cli.html#common-parameters
- [x] Add documentation about these user-configurable options
- [ ] Some of the options are available to be overridden by environment variables, adjust the default values in the `setup()` function?
- [x] Address potential conflicts with options, as noted by @steppi in #168, copying here for ease of access:

> except we might want to document how to avoid having options that conflict with the ones that are currently included, and put in place safeguards to prevent conflicting options

## Additional context

Since the `jupyterlite-pyodide` kernel doesn't support pre-installing packages right now, it's not possible to add `requirements.txt` files. Users shall have to use the `emscripten-forge` channel and the `xeus` kernel to get the packages they need.