### PR TITLE
Hide buttons generated by the `TryExamples` directive by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,3 @@ docs/build
 build
 dist
 .jupyterlite.doit.db
-/.vscode/

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ docs/build
 build
 dist
 .jupyterlite.doit.db
+/.vscode/

--- a/jupyterlite_sphinx/jupyterlite_sphinx.css
+++ b/jupyterlite_sphinx/jupyterlite_sphinx.css
@@ -58,6 +58,7 @@
   background:
     radial-gradient(farthest-side, #ffa516 94%, #0000) top/8px 8px no-repeat,
     conic-gradient(#0000 30%, #ffa516);
+  mask: radial-gradient(farthest-side, #0000 calc(100% - 8px), #000 0);
   -webkit-mask: radial-gradient(farthest-side, #0000 calc(100% - 8px), #000 0);
   animation: l13 1s infinite linear;
 }
@@ -74,4 +75,26 @@
   div.try_examples_button_container {
     display: none;
   }
+}
+
+/* Some improvements for hidden buttons */
+
+/* smooth transitions */
+.try_examples_button {
+  opacity: 1;
+  transition: opacity 0.3s ease-in-out;
+}
+
+.try_examples_button.hidden {
+  display: none;
+  opacity: 0;
+}
+
+.try_examples_button.fade-in {
+  transition: opacity 0.3s ease-in-out;
+}
+
+/* to ensure hidden class takes precedence */
+.hidden {
+  display: none !important;
 }

--- a/jupyterlite_sphinx/jupyterlite_sphinx.js
+++ b/jupyterlite_sphinx/jupyterlite_sphinx.js
@@ -185,7 +185,7 @@ window.loadTryExamplesConfig = async (configFilePath) => {
     Patterns = data.ignore_patterns;
     for (let pattern of Patterns) {
       let regex = new RegExp(pattern);
-      if (!regex.test(currentPageUrl)) {
+      if (regex.test(currentPageUrl)) {
         var buttons = document.getElementsByClassName(
           "try_examples_button hidden",
         );

--- a/jupyterlite_sphinx/jupyterlite_sphinx.js
+++ b/jupyterlite_sphinx/jupyterlite_sphinx.js
@@ -180,15 +180,18 @@ window.loadTryExamplesConfig = async (configFilePath) => {
       tryExamplesGlobalMinHeight = parseInt(data.global_min_height);
     }
 
-    // Disable interactive examples if file matches one of the ignore patterns
-    // by hiding try_examples_buttons.
+    // Selectively enable interactive examples if file matches one of the ignore patterns
+    // by un-hiding try_examples_buttons.
     Patterns = data.ignore_patterns;
     for (let pattern of Patterns) {
       let regex = new RegExp(pattern);
-      if (regex.test(currentPageUrl)) {
-        var buttons = document.getElementsByClassName("try_examples_button");
+      if (!regex.test(currentPageUrl)) {
+        var buttons = document.getElementsByClassName(
+          "try_examples_button hidden",
+        );
         for (var i = 0; i < buttons.length; i++) {
-          buttons[i].classList.add("hidden");
+          console.log(buttons[i]);
+          buttons[i].classList.remove("hidden");
         }
         break;
       }

--- a/jupyterlite_sphinx/jupyterlite_sphinx.js
+++ b/jupyterlite_sphinx/jupyterlite_sphinx.js
@@ -205,7 +205,7 @@ window.loadTryExamplesConfig = async (configFilePath) => {
 window.toggleTryExamplesButtons = () => {
   /* Toggle visibility of TryExamples buttons. For use in console for debug
    * purposes. */
-  var buttons = document.getElementsByClassName("try_examples_button");
+  var buttons = document.getElementsByClassName("try_examples_button hidden");
 
   for (var i = 0; i < buttons.length; i++) {
     buttons[i].classList.toggle("hidden");

--- a/jupyterlite_sphinx/jupyterlite_sphinx.js
+++ b/jupyterlite_sphinx/jupyterlite_sphinx.js
@@ -163,8 +163,18 @@ window.loadTryExamplesConfig = async (configFilePath) => {
     const response = await fetch(configFileUrl);
     if (!response.ok) {
       if (response.status === 404) {
-        // Try examples ignore file is not present.
+        // Try examples ignore file is not present. Enable all interactive examples
+        // in that case.
         console.log("Optional try_examples config file not found.");
+
+        var buttons = document.getElementsByClassName(
+          "try_examples_button hidden",
+        );
+        for (var i = 0; i < buttons.length; i++) {
+          buttons[i].classList.remove("hidden");
+        }
+        tryExamplesConfigLoaded = true;
+
         return;
       }
       throw new Error(`Error fetching ${configFilePath}`);
@@ -195,11 +205,11 @@ window.loadTryExamplesConfig = async (configFilePath) => {
         }
         break;
       }
+      tryExamplesConfigLoaded = true;
     }
   } catch (error) {
     console.error(error);
   }
-  tryExamplesConfigLoaded = true;
 };
 
 window.toggleTryExamplesButtons = () => {

--- a/jupyterlite_sphinx/jupyterlite_sphinx.js
+++ b/jupyterlite_sphinx/jupyterlite_sphinx.js
@@ -185,7 +185,7 @@ window.loadTryExamplesConfig = async (configFilePath) => {
     Patterns = data.ignore_patterns;
     for (let pattern of Patterns) {
       let regex = new RegExp(pattern);
-      if (regex.test(currentPageUrl)) {
+      if (!regex.test(currentPageUrl)) {
         var buttons = document.getElementsByClassName(
           "try_examples_button hidden",
         );

--- a/jupyterlite_sphinx/jupyterlite_sphinx.py
+++ b/jupyterlite_sphinx/jupyterlite_sphinx.py
@@ -553,6 +553,7 @@ class TryExamplesDirective(SphinxDirective):
         )
 
         # Button with the onclick event to swap embedded notebook back to examples.
+        # This includes a 'hidden' class by default to hide until the page is loaded.
         go_back_button_html = (
             '<button class="try_examples_button hidden" '
             f"onclick=\"window.tryExamplesHideIframe('{examples_div_id}',"

--- a/jupyterlite_sphinx/jupyterlite_sphinx.py
+++ b/jupyterlite_sphinx/jupyterlite_sphinx.py
@@ -468,14 +468,14 @@ class TryExamplesDirective(SphinxDirective):
 
         # Button with the onclick event to swap embedded notebook back to examples.
         go_back_button_html = (
-            '<button class="try_examples_button" '
+            '<button class="try_examples_button hidden" '
             f"onclick=\"window.tryExamplesHideIframe('{examples_div_id}',"
             f"'{iframe_parent_div_id}')\">"
             "Go Back</button>"
         )
 
         full_screen_button_html = (
-            '<button class="try_examples_button" '
+            '<button class="try_examples_button hidden" '
             f"onclick=\"window.openInNewTab('{examples_div_id}',"
             f"'{iframe_parent_div_id}')\">"
             "Open In Tab</button>"
@@ -484,7 +484,7 @@ class TryExamplesDirective(SphinxDirective):
         # Button with the onclick event to swap examples with embedded notebook.
         try_it_button_html = (
             '<div class="try_examples_button_container">'
-            '<button class="try_examples_button" '
+            '<button class="try_examples_button hidden" '
             f"onclick=\"window.tryExamplesShowIframe('{examples_div_id}',"
             f"'{iframe_div_id}','{iframe_parent_div_id}','{iframe_src}',"
             f"'{height}')\">"


### PR DESCRIPTION
## Description

This PR hides the buttons from the `TryExamples` directive by default. This is helpful because the current method of ignoring particular pages based on their URL first loads the buttons and then hides them, which means that they are briefly displayed on that page in the documentation and then hidden – keeping them hidden and then selectively enabling them will minimise this latency and improve user experience.

## Changes made

1. Made all `try_examples_button` buttons `hidden` at the time of generation by adding this keyword to the `classList`
2. Updated the `loadTryExamplesConfig` function in `jupyterlite_sphinx.js` to check for the `try_examples_button hidden` class instead and then remove `hidden` from the `classList`
3. 

## Additional context

N/A
