### PR TITLE
Use the latest `jupyterlite-xeus` to fix the docs build

### DIFF
--- a/dev-environment.yml
+++ b/dev-environment.yml
@@ -5,9 +5,9 @@ dependencies:
     - pip
     - jupyter_server
     - jupyterlab_server
-    - jupyterlite-xeus >=0.1.8,<0.2.0
     - jupyterlite-core >=0.3,<0.4
     - pydata-sphinx-theme
+    - micromamba
     - myst-parser
     - docutils
     - sphinx
@@ -15,3 +15,4 @@ dependencies:
     - voici
     - pip:
         - .
+        - jupyterlite-xeus >=0.2.0a0

--- a/dev-environment.yml
+++ b/dev-environment.yml
@@ -6,7 +6,7 @@ dependencies:
     - jupyter_server
     - jupyterlab_server
     - jupyterlite-xeus >=0.1.8,<0.2.0
-    - jupyterlite-core >=0.2,<0.4
+    - jupyterlite-core >=0.3,<0.4
     - pydata-sphinx-theme
     - myst-parser
     - docutils


### PR DESCRIPTION
Troubleshoot the recent docs failure, as seen on the latest build: https://readthedocs.org/projects/jupyterlite-sphinx/builds/24659541/

And also in https://github.com/jupyterlite/jupyterlite-sphinx/pull/178