### PR TITLE
Strip tagged cells from `.ipynb` notebooks passed to the `NotebookLite` and `JupyterLite` directives

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -11,6 +11,7 @@ html_logo = "_static/icon.svg"
 
 jupyterlite_contents = "./custom_contents"
 jupyterlite_bind_ipynb_suffix = False
+strip_tagged_cells = True
 
 master_doc = "index"
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -64,12 +64,13 @@ This behaviour can be enabled by setting the following config:
 strip_tagged_cells = True
 ```
 
-and then tag the cells you want to strip with the tag `strip` in the JSON metadata of the cell, like this:
+and then tag the cells you want to strip with the tag `jupyterlite_sphinx_strip` in the JSON metadata
+of the cell, like this:
 
 ```json
 {
   "tags": [
-    "strip": "true"
+    "jupyterlite_sphinx_strip": "true"
   ]
 }
 ```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -55,9 +55,10 @@ jupyterlite_config = "jupyterlite_config.json"
 
 ## Strip particular tagged cells from IPython Notebooks
 
-When using the `NotebookLite` or the `JupyterLite` directives with a notebook passed, you can add strip particular tagged cells from the notebook before rendering it in the JupyterLite console.
+When using the `NotebookLite`, `JupyterLite`, or `Voici` directives with a notebook passed, you can
+strip particular tagged cells from the notebook before rendering it in the JupyterLite console.
 
-You can enable this behaviour by setting the following config:
+This behaviour can be enabled by setting the following config:
 
 ```python
 strip_tagged_cells = True
@@ -73,9 +74,12 @@ and then tag the cells you want to strip with the tag `strip` in the JSON metada
 }
 ```
 
-This is useful when you want to remove some cells from the rendered notebook in the JupyterLite console, for example, cells that are used for adding reST-based directives or other Sphinx-specific content.
+This is useful when you want to remove some cells from the rendered notebook in the JupyterLite
+console, for example, cells that are used for adding reST-based directives or other
+Sphinx-specific content.
 
-For example, you can use this feature to remove the `toctree` directive from the rendered notebook in the JupyterLite console:
+For example, you can use this feature to remove the `toctree` directive from the rendered notebook
+in the JupyterLite console:
 
 ```json
 {
@@ -107,9 +111,12 @@ For example, you can use this feature to remove the `toctree` directive from the
 }
 ```
 
-where the cell with the `toctree` directive will be removed from the rendered notebook in the JupyterLite console.
+where the cell with the `toctree` directive will be removed from the rendered notebook in
+the JupyterLite console.
 
-Note that this feature is only available for the `NotebookLite` and `JupyterLite` directives and works with the `ipynb` files passed to them, and therefore does not work with the `TryExamples` directive.
+Note that this feature is only available for the `NotebookLite`, `JupyterLite`, and the
+`Voici` directives and works with the `ipynb` files passed to them, and therefore does
+not work with the `TryExamples` directive.
 
 ## Disable the `.ipynb` docs source binding
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -53,6 +53,64 @@ to your JupyterLite deployment.
 jupyterlite_config = "jupyterlite_config.json"
 ```
 
+## Strip particular tagged cells from IPython Notebooks
+
+When using the `NotebookLite` or the `JupyterLite` directives with a notebook passed, you can add strip particular tagged cells from the notebook before rendering it in the JupyterLite console.
+
+You can enable this behaviour by setting the following config:
+
+```python
+strip_tagged_cells = True
+```
+
+and then tag the cells you want to strip with the tag `strip` in the JSON metadata of the cell, like this:
+
+```json
+{
+  "tags": [
+    "strip": "true"
+  ]
+}
+```
+
+This is useful when you want to remove some cells from the rendered notebook in the JupyterLite console, for example, cells that are used for adding reST-based directives or other Sphinx-specific content.
+
+For example, you can use this feature to remove the `toctree` directive from the rendered notebook in the JupyterLite console:
+
+```ipynb
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "tags": [
+          "strip": "true"
+        ]
+      },
+      "source": [
+        "# Table of Contents\n",
+        "\n",
+        "```{toctree}\n",
+        ":maxdepth: 2\n",
+        "\n",
+        "directives/jupyterlite\n",
+        "directives/notebooklite\n",
+        "directives/replite\n",
+        "directives/voici\n",
+        "directives/try_examples\n",
+        "full\n",
+        "changelog\n",
+        "```"
+      ]
+    }
+  ]
+}
+```
+
+where the cell with the `toctree` directive will be removed from the rendered notebook in the JupyterLite console.
+
+Note that this feature is only available for the `NotebookLite` and `JupyterLite` directives and works with the `ipynb` files passed to them, and therefore does not work with the `TryExamples` directive.
+
 ## Disable the `.ipynb` docs source binding
 
 By default, jupyterlite-sphinx binds the `.ipynb` source suffix so that it renders Notebooks included in the doctree with JupyterLite.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -77,7 +77,7 @@ This is useful when you want to remove some cells from the rendered notebook in 
 
 For example, you can use this feature to remove the `toctree` directive from the rendered notebook in the JupyterLite console:
 
-```ipynb
+```json
 {
   "cells": [
     {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -55,7 +55,7 @@ jupyterlite_config = "jupyterlite_config.json"
 
 ## Strip particular tagged cells from IPython Notebooks
 
-When using the `NotebookLite`, `JupyterLite`, or `Voici` directives with a notebook passed, you can
+When using the `NotebookLite`, `JupyterLite`, or `Voici` directives with a notebook passed to them, you can
 strip particular tagged cells from the notebook before rendering it in the JupyterLite console.
 
 This behaviour can be enabled by setting the following config:
@@ -64,7 +64,7 @@ This behaviour can be enabled by setting the following config:
 strip_tagged_cells = True
 ```
 
-and then tag the cells you want to strip with the tag `jupyterlite_sphinx_strip` in the JSON metadata
+and then by tagging the cells you want to strip with the tag `jupyterlite_sphinx_strip` in the JSON metadata
 of the cell, like this:
 
 ```json
@@ -89,7 +89,7 @@ in the JupyterLite console:
       "cell_type": "markdown",
       "metadata": {
         "tags": [
-          "strip": "true"
+          "jupyterlite_sphinx_strip": "true"
         ]
       },
       "source": [
@@ -116,8 +116,8 @@ where the cell with the `toctree` directive will be removed from the rendered no
 the JupyterLite console.
 
 Note that this feature is only available for the `NotebookLite`, `JupyterLite`, and the
-`Voici` directives and works with the `ipynb` files passed to them, and therefore does
-not work with the `TryExamples` directive.
+`Voici` directives and works with the `.ipynb` files passed to them. It is not implemented
+for the `TryExamples` directive.
 
 ## Disable the `.ipynb` docs source binding
 

--- a/docs/directives/my_notebook.ipynb
+++ b/docs/directives/my_notebook.ipynb
@@ -23,9 +23,7 @@
    "cell_type": "code",
    "execution_count": 2,
    "id": "84361143",
-   "metadata": {
-    "strip": "true"
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -36,8 +34,7 @@
     }
    ],
    "source": [
-    "foo()\n",
-    "# This cell contains \"strip\": \"true\" in the metadata and therefore won't exist"
+    "foo()"
    ]
   },
   {
@@ -46,9 +43,7 @@
    "id": "b9f8bed0",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "# This cell will exist because it hasn't been tagged"
-   ]
+   "source": []
   }
  ],
  "metadata": {

--- a/docs/directives/my_notebook.ipynb
+++ b/docs/directives/my_notebook.ipynb
@@ -23,7 +23,9 @@
    "cell_type": "code",
    "execution_count": 2,
    "id": "84361143",
-   "metadata": {},
+   "metadata": {
+    "strip": "true"
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -34,7 +36,8 @@
     }
    ],
    "source": [
-    "foo()"
+    "foo()\n",
+    "# This cell contains \"strip\": \"true\" in the metadata and therefore won't exist"
    ]
   },
   {
@@ -43,7 +46,9 @@
    "id": "b9f8bed0",
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "# This cell will exist because it hasn't been tagged"
+   ]
   }
  ],
  "metadata": {

--- a/jupyterlite_sphinx/jupyterlite_sphinx.py
+++ b/jupyterlite_sphinx/jupyterlite_sphinx.py
@@ -346,10 +346,6 @@ class _LiteDirective(SphinxDirective):
             os.makedirs(os.path.dirname(notebooks_dir), exist_ok=True)
 
             if notebook_is_stripped:
-                print(
-                    f"{notebook}: Removing cells tagged with 'strip' metadata set to 'true'"
-                )
-
                 # Note: the directives meant to be stripped must be inside their own
                 # cell so that the cell itself gets removed from the notebook. This
                 # is so that we don't end up removing useful data or directives that
@@ -363,17 +359,13 @@ class _LiteDirective(SphinxDirective):
                     for cell in nb.cells
                     if "true" not in cell.metadata.get("strip", [])
                 ]
-                print(f"Writing stripped notebook to {notebooks_dir}")
                 nbformat.write(nb, notebooks_dir, version=4)
 
-                # If notebook_is_stripped is False, then copy the notebook(s) to notebooks_dir.
-                # If it is True, then they have already been copied to notebooks_dir by the
-                # nbformat.write() function above.
-                if not notebook_is_stripped:
-                    print(
-                        f"Notebooks are not stripped, copying {notebook_name} to {notebooks_dir}"
-                    )
-                    shutil.copy(notebook, notebooks_dir)
+            # If notebook_is_stripped is False, then copy the notebook(s) to notebooks_dir.
+            # If it is True, then they have already been copied to notebooks_dir by the
+            # nbformat.write() function above.
+            else:
+                shutil.copy(notebook, notebooks_dir)
         else:
             notebook_name = None
 

--- a/jupyterlite_sphinx/jupyterlite_sphinx.py
+++ b/jupyterlite_sphinx/jupyterlite_sphinx.py
@@ -366,17 +366,14 @@ class _LiteDirective(SphinxDirective):
                 print(f"Writing stripped notebook to {notebooks_dir}")
                 nbformat.write(nb, notebooks_dir, version=4)
 
-            try:
-                # if notebook_is_stripped is False, then copy the notebook(s) to notebooks_dir.
-                # if it is True, then it is already copied to notebooks_dir by nbformat.write
-                # above.
+            # If notebook_is_stripped is False, then copy the notebook(s) to notebooks_dir.
+            # If it is True, then they have already been copied to notebooks_dir by the
+            # nbformat.write() function above.
                 if not notebook_is_stripped:
                     print(
                         f"Notebooks are not stripped, copying {notebook_name} to {notebooks_dir}"
                     )
                     shutil.copy(notebook, notebooks_dir)
-            except shutil.SameFileError:
-                pass
         else:
             notebook_name = None
 

--- a/jupyterlite_sphinx/jupyterlite_sphinx.py
+++ b/jupyterlite_sphinx/jupyterlite_sphinx.py
@@ -347,12 +347,15 @@ class _LiteDirective(SphinxDirective):
             # are expected to be found.
 
             import tempfile
+
             temp_dir = tempfile.mkdtemp()
             # Copy notebooks in notebooks_dir to temp_dir
             shutil.copy(notebook, temp_dir)
 
             if self.env.config.strip_tagged_cells:
-                print(f"{notebook}: Removing cells tagged with 'strip' metadata set to 'true'")
+                print(
+                    f"{notebook}: Removing cells tagged with 'strip' metadata set to 'true'"
+                )
 
                 # Note: the directives meant to be stripped must be inside their own
                 # cell so that the cell itself gets removed from the notebook. This

--- a/jupyterlite_sphinx/jupyterlite_sphinx.py
+++ b/jupyterlite_sphinx/jupyterlite_sphinx.py
@@ -366,9 +366,9 @@ class _LiteDirective(SphinxDirective):
                 print(f"Writing stripped notebook to {notebooks_dir}")
                 nbformat.write(nb, notebooks_dir, version=4)
 
-            # If notebook_is_stripped is False, then copy the notebook(s) to notebooks_dir.
-            # If it is True, then they have already been copied to notebooks_dir by the
-            # nbformat.write() function above.
+                # If notebook_is_stripped is False, then copy the notebook(s) to notebooks_dir.
+                # If it is True, then they have already been copied to notebooks_dir by the
+                # nbformat.write() function above.
                 if not notebook_is_stripped:
                     print(
                         f"Notebooks are not stripped, copying {notebook_name} to {notebooks_dir}"


### PR DESCRIPTION
## Description

This PR updates the `_LiteDirective` class to be able to use `nbformat`, which is already specified as a dependency in `pyproject.toml`, to be able to read IPyNB files and remove cells which include "strip" set to "true" in their JSON metadata. This way, it is possible to provide cleaner notebooks for cases similar to https://github.com/scipy/scipy/pull/20303 or with https://github.com/PyWavelets/pywt/pull/741, where notebooks passed to the `.. notebooklite::` or the `.. jupyterlite::` directives can now be preprocessed to remove certain cells before they are copied to the built documentation.

For example, a notebook cell with the Markdown syntax

````markdown
```{note}
This text should not exist in the notebook in the built documentation
```
````

can receive metadata like this

```json
{
  "tags": [
    "strip": "true"
  ]
}
```

and this cell will be removed by `nbformat` if `strip_tagged_cells` is set to `True` in `conf.py`, therefore disabling the admonition in the deployed documentation.

## Changes made

1. Added a configuration value for the Sphinx extension, `strip_tagged_cells` which is set to `False` by default. If set to `True` in `conf.py`, this enables preprocessing behaviour
2. The preprocessing behaviour is in `jupyterlite_sphinx/jupyterlite_sphinx.py`, where `nbformat` is used to read the notebook file and operate on the cells of the notebook.
3. This feature has been documented in `docs/configuration.md`.

## Additional context

- The `TryExamples` directive is not compatible with this feature. This is because we need an IPyNB-based notebook file to add metadata for a cell, while `TryExamples` dynamically generates notebooks at runtime from doctests.
