### PR TITLE
Issue 115 wrap fullscreen JupyterLite links

### DIFF
--- a/docs/full.md
+++ b/docs/full.md
@@ -7,7 +7,11 @@ JupyterLite instance in a separate tab.
 
 You can access the JupyterLite deployment that `jupyterlite-sphinx` made for you, in fullscreen, following the `./lite/lab` and `./lite/retro` relative urls:
 
-- [JupyterLab](./lite/lab/index.html)
-- [Notebook](./lite/tree/index.html)
+```{eval-rst}
 
-If you want to open a specific notebook in fullscreen  JupyterLab/Notebook you can use the `path` URL parameter, e.g. `./lite/lab/?path=my_noteboook.ipynb`.
+- `JupyterLab <lite/lab/index.html>`_
+- `Notebook <lite/tree/index.html>`_
+
+```
+
+If you want to open a specific notebook in fullscreen JupyterLab/Notebook, you can use the `path` URL parameter, e.g. `./lite/lab/?path=my_noteboook.ipynb`.


### PR DESCRIPTION
## Description

Closes #115; the Markdown-based links act as anchors and therefore the relative URLs that point to the JupyterLite deployment in the documentation do not work. This PR wraps them in reST-based syntax using ```{eval-rst}``` for Sphinx to be able to correctly interpret the links.