### PR TITLE
`TryExamples` directive: fix missing kernels in CircleCI deployments

### DIFF
--- a/jupyterlite_sphinx/jupyterlite_sphinx.py
+++ b/jupyterlite_sphinx/jupyterlite_sphinx.py
@@ -512,7 +512,7 @@ class TryExamplesDirective(SphinxDirective):
 
         iframe_parent_div_id = uuid4()
         iframe_div_id = uuid4()
-        iframe_src = f'{prefix}/{app_path}{f"?{options}" if options else ""}'
+        iframe_src = f'{prefix}/{app_path}{f"index.html?{options}" if options else ""}'
 
         # Parent container (initially hidden)
         iframe_parent_container_div_start = (


### PR DESCRIPTION
## Description

This PR updates the URL used to access the notebooks generated by the `TryExamples` directive, similar to https://github.com/sphinx-gallery/sphinx-gallery/pull/1336. This enables viewing and interacting with the examples on Sphinx-based documentation websites.

As originally mentioned in the above issue, here is a [related discussion](https://discuss.circleci.com/t/circle-artifacts-com-not-using-index-html/320). Adding `index.html` to the URL somehow makes the notebooks/examples display as intended when the  "Try it" or the "Open in tab" buttons are clicked.

## Additional context

This came up in https://github.com/numpy/numpy/pull/26745/ where I am trying to integrate `jupyterlite-sphinx` for the NumPy v2 documentation website, which uses CircleCI artifacts for documentation builds on PRs.

P.S. Thanks to @lesteve for the pointer!