### PR TITLE
Hotfix: cell metadata to parse should be `jupyterlite_sphinx_strip`

### DIFF
--- a/jupyterlite_sphinx/jupyterlite_sphinx.py
+++ b/jupyterlite_sphinx/jupyterlite_sphinx.py
@@ -357,7 +357,7 @@ class _LiteDirective(SphinxDirective):
                 nb.cells = [
                     cell
                     for cell in nb.cells
-                    if "true" not in cell.metadata.get("strip", [])
+                    if "true" not in cell.metadata.get("jupyterlite_sphinx_strip", [])
                 ]
                 nbformat.write(nb, notebooks_dir, version=4)
 


### PR DESCRIPTION
## Description

This is a small fix that I missed adding in #180