### PR TITLE
Fix invalid schema for `jupyterlite_sphinx_strip` tag when `strip_tagged_cells` is `True`

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -68,9 +68,9 @@ and then by tagging the cells you want to strip with the tag `jupyterlite_sphinx
 of the cell, like this:
 
 ```json
-{
+"metadata": {
   "tags": [
-    "jupyterlite_sphinx_strip": "true"
+    "jupyterlite_sphinx_strip"
   ]
 }
 ```
@@ -89,7 +89,7 @@ in the JupyterLite console:
       "cell_type": "markdown",
       "metadata": {
         "tags": [
-          "jupyterlite_sphinx_strip": "true"
+          "jupyterlite_sphinx_strip"
         ]
       },
       "source": [

--- a/jupyterlite_sphinx/jupyterlite_sphinx.py
+++ b/jupyterlite_sphinx/jupyterlite_sphinx.py
@@ -352,12 +352,10 @@ class _LiteDirective(SphinxDirective):
                 # are not meant to be removed.
 
                 nb = nbformat.read(notebook, as_version=4)
-                print(f"Opened {notebook_name}")
-                nb = nbformat.read(notebook, as_version=4)
                 nb.cells = [
                     cell
                     for cell in nb.cells
-                    if "true" not in cell.metadata.get("jupyterlite_sphinx_strip", [])
+                    if "jupyterlite_sphinx_strip" not in cell.metadata.get("tags", [])
                 ]
                 nbformat.write(nb, notebooks_dir, version=4)
 


### PR DESCRIPTION
## Description

```json
"metadata": {
        "tags": [
          "jupyterlite_sphinx_strip": "true"
        ]
      }
```

is invalid for notebook-based metadata, while `"jupyterlite_sphinx_strip"` is valid. This was incorrectly mentioned in the documentation and was not caught because we were trying to parse the cell metadata itself. We now check for the existence of a tag in the metadata rather than trying to find it as a key-value pair in the metadata for a cell. This is a fix that is a candidate for a v0.16.1 release.

<hr>

cc: @steppi 