### PR TITLE
Fix incorrect regex usage instructions for `TryExamples` JSON configuration file

### DIFF
--- a/docs/directives/try_examples.md
+++ b/docs/directives/try_examples.md
@@ -240,28 +240,31 @@ The format is a list of
 
 ```json
 {
-    "ignore_patterns": ["^/latest/.*", "^/stable/reference/generated/example.html"]
+    "ignore_patterns": ["^\/latest/.*", "^\/stable\/reference\/generated\/example.html"]
 }
 ```
 
 `TryExamples` buttons will be hidden in url pathnames matching at least one of these
 patterns, effectively disabling the interactive documentation. In the provided example:
 
-* The pattern `"^/latest/.*"` disables interactive examples for urls for the documentation
+* The pattern `"^\/latest\/.*"` disables interactive examples for urls for the documentation
   for the latest version of the package, which may be useful if this documentation is
   for a development version for which a corresponding package build is not available
-  in a Jupyterlite kernel.
+  in a JupyterLite kernel.
 
-* The pattern `"^/stable/reference/generated/example.html"` targets a particular url
+* The pattern `"^\/stable\/reference\/generated\/example.html"` targets a particular url
   in the documentation for the latest stable release.
 
 Note that these patterns should match the [pathname](https://developer.mozilla.org/en-US/docs/Web/API/Location/pathname) of the url, not the full url. This is the path portion of
-the url. For instance, the pathname of https://jupyterlite-sphinx.readthedocs.io/en/latest/directives/try_examples.html is `/en/latest/directives/try_examples.html`.
+the url. For instance, the pathname of https://jupyterlite-sphinx.readthedocs.io/en/latest/directives/try_examples.html is `/en/latest/directives/try_examples.html`. Also, note that since these are JavaScript-based regular
+expressions, to use special characters in the regular expression (such as `/`), they
+must be escaped with a backslash (`\`).
 
 Again, the configuration file can be added or edited within the deployed documentation,
 allowing for disabling or enabling examples without rebuilding the documentation.
 
 #### "global_min_height"
+
 To avoid having unusably small notebooks for very small examples due to the default of
 having the embedded notebooks' iframe containers take the same amount of space as the
 rendered content they replace, users can set a global minimum height in


### PR DESCRIPTION
## Description

According to the JavaScript (ECMAScript) standard for regular expressions, forward slashes (`/`) need to be escaped properly through backslashes (`\`), which means that the current instructions in the documentation raise errors on popular regular expression checker websites such as https://regex101.com/ and https://regexr.com/. While they work on most browsers without issues since `RegExp` is supported almost everywhere and browsers likely escape the string on their own, I thought that updating the documentation here through this PR to adhere to the correct method of escaping special characters would be beneficial.

## Additional context

* See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_expressions#escaping
* xref to numpy/numpy#26745 where I observed this when disabling interactive examples from certain pages