### PR TITLE
Fix compatibility with Sphinx 8

### DIFF
--- a/jupyterlite_sphinx/jupyterlite_sphinx.py
+++ b/jupyterlite_sphinx/jupyterlite_sphinx.py
@@ -4,7 +4,7 @@ from uuid import uuid4
 import shutil
 import glob
 import re
-from typing import Dict, Any
+from typing import Dict, Any, List
 
 from pathlib import Path
 
@@ -608,9 +608,9 @@ class TryExamplesDirective(SphinxDirective):
         return [content_container_node, notebook_container, script_node]
 
 
-def _process_docstring_examples(app, docname, source):
-    source_path = app.env.doc2path(docname)
-    if source_path.endswith(".py"):
+def _process_docstring_examples(app: Sphinx, docname: str, source: List[str]) -> None:
+    source_path: os.PathLike = Path(app.env.doc2path(docname))
+    if source_path.suffix == ".py":
         source[0] = insert_try_examples_directive(source[0])
 
 

--- a/jupyterlite_sphinx/jupyterlite_sphinx.py
+++ b/jupyterlite_sphinx/jupyterlite_sphinx.py
@@ -609,8 +609,8 @@ class TryExamplesDirective(SphinxDirective):
 
 
 def _process_docstring_examples(app: Sphinx, docname: str, source: List[str]) -> None:
-    source_path: os.PathLike = Path(app.env.doc2path(docname))
-    if source_path.suffix == ".py":
+    source_path: str = str(app.env.doc2path(docname))
+    if source_path.endswith(".py"):
         source[0] = insert_try_examples_directive(source[0])
 
 

--- a/jupyterlite_sphinx/jupyterlite_sphinx.py
+++ b/jupyterlite_sphinx/jupyterlite_sphinx.py
@@ -609,8 +609,8 @@ class TryExamplesDirective(SphinxDirective):
 
 
 def _process_docstring_examples(app: Sphinx, docname: str, source: List[str]) -> None:
-    source_path: str = str(app.env.doc2path(docname))
-    if source_path.endswith(".py"):
+    source_path: str = app.env.doc2path(docname)
+    if source_path.suffix == ".py":
         source[0] = insert_try_examples_directive(source[0])
 
 


### PR DESCRIPTION
## Description

The function `_process_docstring_examples` used `app.env.doc2path`, which now needs paths instead of strings, since Sphinx 9 will drop support for representing paths as strings, which was raising warnings for the new release of Sphinx, i.e., version 8. This uses `pathlib.Path()` to process the path. A few other type hints have been added to the function's arguments.

Closes #197

## Additional context

xref docs build failures in SciPy downstream: https://github.com/scipy/scipy/issues/21323, https://github.com/scipy/scipy/pull/21324