### PR TITLE
Restore backwards compatibility with Sphinx <8

### DIFF
--- a/jupyterlite_sphinx/jupyterlite_sphinx.py
+++ b/jupyterlite_sphinx/jupyterlite_sphinx.py
@@ -609,7 +609,7 @@ class TryExamplesDirective(SphinxDirective):
 
 
 def _process_docstring_examples(app: Sphinx, docname: str, source: List[str]) -> None:
-    source_path: str = app.env.doc2path(docname)
+    source_path: os.PathLike = Path(app.env.doc2path(docname))
     if source_path.suffix == ".py":
         source[0] = insert_try_examples_directive(source[0])
 


### PR DESCRIPTION
## Description

See https://github.com/numpy/numpy/pull/26745#issuecomment-2273605967 where I encountered this. #199 ensured compatibility with Sphinx 8 after https://github.com/scipy/scipy/issues/21323 was opened (temporarily pinned in https://github.com/scipy/scipy/pull/21324), but it seems to have broken compatibility with older versions of Sphinx (6 and 7, for example). @steppi, I have restored the original fix from #199, since I can't find older versions of the Sphinx documentation to read through – it seems that they publish just the version from the `master` branch. These changes should work with both Sphinx 8 and earlier versions.