### PR TITLE
Fix the opening of notebooks in a new tab when using the `JupyterLite` and `Voici` directives

### DIFF
--- a/docs/full.md
+++ b/docs/full.md
@@ -14,4 +14,4 @@ You can access the JupyterLite deployment that `jupyterlite-sphinx` made for you
 
 ```
 
-If you want to open a specific notebook in fullscreen JupyterLab/Notebook, you can use the `path` URL parameter, e.g. `./lite/lab/?path=my_noteboook.ipynb`.
+If you want to open a specific notebook in fullscreen JupyterLab/Notebook, you can use the `path` URL parameter, e.g. `./lite/lab/index.html?path=my_noteboook.ipynb`.

--- a/jupyterlite_sphinx/jupyterlite_sphinx.py
+++ b/jupyterlite_sphinx/jupyterlite_sphinx.py
@@ -129,7 +129,9 @@ class _InTab(Element):
         options = "&".join(
             [f"{key}={quote(value)}" for key, value in lite_options.items()]
         )
-        self.lab_src = f'{prefix}/{app_path}{f"?{options}" if options else ""}'
+        self.lab_src = (
+            f'{prefix}/{app_path}{f"index.html?{options}" if options else ""}'
+        )
 
         super().__init__(
             rawsource,
@@ -170,7 +172,7 @@ class _LiteIframe(_PromptedIframe):
             [f"{key}={quote(value)}" for key, value in lite_options.items()]
         )
 
-        iframe_src = f'{prefix}/{app_path}{f"?{options}" if options else ""}'
+        iframe_src = f'{prefix}/{app_path}{f"index.html?{options}" if options else ""}'
 
         if "iframe_src" in attributes:
             if attributes["iframe_src"] != iframe_src:
@@ -246,7 +248,7 @@ class VoiciIframe(_PromptedIframe):
             [f"{key}={quote(value)}" for key, value in lite_options.items()]
         )
 
-        iframe_src = f'{prefix}/{app_path}{f"?{options}" if options else ""}'
+        iframe_src = f'{prefix}/{app_path}{f"index.html?{options}" if options else ""}'
 
         super().__init__(rawsource, *children, iframe_src=iframe_src, **attributes)
 


### PR DESCRIPTION
## Description

The JupyterLite directive allows for a `:new_tab:` configuration option that was established in #165, which does what it says: provide a button to open a notebook file passed to it with the JupyterLite interface in a new tab. This PR adds the `index.html` prefix to the URL similar to #182 to fix the loading of the notebooks – without this, we arrive at the file server and JupyterLite does not load until we browse into the `docs/_contents/` directory ourselves.

## Changes made

- The `index.html` prefix has been added to the JupyterLite app URLs for all directives/apps. This prefix previously existed only for the `TryExamples` directive.

## Additional context

I came across this when testing the SciPy docs builds locally when attempting a fix for #191 while working on the `scipy.stats` notebooks, which did not load properly in new tabs until this change was made.

cc: @melissawm