### PR TITLE
Add an option to open the Notebook UI and Voici apps in a new tab via the`NotebookLite` and `Voici` directives

### DIFF
--- a/docs/directives/jupyterlite.md
+++ b/docs/directives/jupyterlite.md
@@ -37,6 +37,8 @@ You can also pass a Notebook file to open automatically:
 ```
 
 If you use the `:new_tab:` option in the directive, the Notebook will be opened in a new browser tab.
+The tab will render the full-fledged Lab interface, which is more complete and showcases all features
+of JupyterLite.
 
 ```rst
 .. jupyterlite:: my_notebook.ipynb

--- a/docs/directives/notebooklite.md
+++ b/docs/directives/notebooklite.md
@@ -31,3 +31,17 @@ You can also pass a Notebook file to open:
    :height: 600px
    :prompt: Try classic Notebook!
 ```
+
+If you use the `:new_tab:` option in the directive, the Notebook will be opened in a new browser tab.
+The tab will render the classic Notebook UI, which is more minimal and does not showcase the entire
+Lab interface.
+
+```rst
+.. notebooklite:: my_notebook.ipynb
+   :new_tab: True
+```
+
+```{eval-rst}
+.. notebooklite:: my_notebook.ipynb
+   :new_tab: True
+```

--- a/docs/directives/voici.md
+++ b/docs/directives/voici.md
@@ -27,3 +27,17 @@ You can provide a notebook that will be rendered with Voici:
    :prompt: Try Voici!
    :prompt_color: #dc3545
 ```
+
+If you use the `:new_tab:` option in the directive, the Voici dashboard will execute and render
+the notebook in a new browser tab, instead of in the current page.
+
+```rst
+.. voici:: my_notebook.ipynb
+   :new_tab: True
+```
+
+```{eval-rst}
+.. voici:: my_notebook.ipynb
+   :new_tab: True
+```
+


### PR DESCRIPTION
## Description

This PR implements #165, but for the Notebook UI and the Voici interface, which come to life via the `..notebooklite::` and `.. voici::` directives and notebooks can now be opened in a separate tab instead of within the documentation website. With it, we also receive the added benefit of a smaller button for both directives IFrames, instead of a larger-sized, framed 400px window element on the screen.

## Rationale

When running a notebook, the `JupyterLite` interface displays the entire JupyterLite Lab interface. The ability to use the Notebook UI in a new tab would be useful because it is more minimal and designed for those who do not need to display all the notebooks in the file browser drawer, need access to several other options, etc.

Unlike in JupyterLab, the "Simple Interface" has not yet been directly implemented in JupyterLite (please see jupyterlite/jupyterlite#385). Thus, this change will allow us to offer a reasonable substitute for it at the time, and bring parity between both notebook interface spawners.

The `Voici` directive can currently open notebook files if a notebook is not supplied to it. However, it, too, occupies a lot of space and one has to first load Voici and then open a notebook. By adding a "new tab" button, we have the provision to skip this step and open the notebook directly, and save space on the screen similar to the "-Lite" directives. This brings parity between all three major directives (the Replite console is not relevant here).

## Changes made

- Abstracted the "open in a new tab" functionality with a "base" class for the tabbed versions of both `JupyterLite` and `NotebookLite` directives
- Created a tabbed interface for the Voici directive
- Added docs for the new `:new_tab:` option for the `NotebookLite` directive and clarified the difference between both directive's "new tab" options
- Added docs for the new `:new_tab:` option for the `Voici` directive

## Additional context

After this change, the NotebookLite directive can be used in place of the JupyterLite directive for many of SciPy's interactive notebooks under `scipy.stats`: https://scipy.github.io/devdocs/tutorial/stats/hypothesis_tests.html, so that a notebook, when opened in a new tab, can occupy the full width on the screen (and distracting elements such as other notebooks in the UI and extra buttons can also be reduced).

cc: @melissawm, @steppi