### PR TITLE
Fix paths for Replite apps

### DIFF
--- a/jupyterlite_sphinx/jupyterlite_sphinx.py
+++ b/jupyterlite_sphinx/jupyterlite_sphinx.py
@@ -190,7 +190,7 @@ class RepliteIframe(_LiteIframe):
     Renders an iframe that shows a repl with JupyterLite.
     """
 
-    lite_app = "repl/index.html"
+    lite_app = "repl/"
     notebooks_path = ""
 
 


### PR DESCRIPTION
## Description

I _might_ have introduced this via #220 – this PR is a small fix so that the Replite app on the landing page of the documentation loads successfully (the "index.html" string was duplicated in the URL).

My apologies!