### PR TITLE
Allow the use of a custom `overrides.json` file for configuring JupyterLite at runtime

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,6 +13,13 @@ jupyterlite_contents = "./custom_contents"
 jupyterlite_bind_ipynb_suffix = False
 strip_tagged_cells = True
 
+# Enable this to use the provided sample overrides JSON file.
+# jupyterlite_overrides = "sample_overrides.json"
+
+# Enable this to unsilence JupyterLite and aid debugging
+# within our own documentation.
+# jupyterlite_silence = False
+
 master_doc = "index"
 
 # General information about the project.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -46,7 +46,7 @@ dependencies:
 
 ## JupyterLite configuration
 
-You can provide [custom configuration files](https://jupyterlite.readthedocs.io/en/latest/howto/configure/config_files.html)
+You can provide [custom configuration files](https://jupyterlite.readthedocs.io/en/stable/howto/configure/config_files.html)
 to your JupyterLite deployment for build-time configuration and settings overrides.
 
 The build-time configuration can be used to change the default settings for JupyterLite, such

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -49,6 +49,14 @@ dependencies:
 You can provide [custom configuration files](https://jupyterlite.readthedocs.io/en/latest/howto/configure/config_files.html)
 to your JupyterLite deployment for build-time configuration and settings overrides.
 
+The build-time configuration can be used to change the default settings for JupyterLite, such
+as changing which assets are included, the locations of the assets, which plugins are enabled,
+and more.
+
+The runtime configuration can be used to change the settings of the JupyterLite deployment
+after it has been built, such as changing the theme, the default kernel, the default language,
+and more.
+
 <!-- TODO: Run-time configuration via `jupyter-lite.json` not added yet here
 because I can't yet find a direct jupyter lite CLI mapping for that option -->
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -44,13 +44,19 @@ dependencies:
   - ipycanvas
 ```
 
-## JupyterLite config
+## JupyterLite configuration
 
-You can provide [custom configuration](https://jupyterlite.readthedocs.io/en/latest/howto/index.html#configuring-a-jupyterlite-deployment)
-to your JupyterLite deployment.
+You can provide [custom configuration files](https://jupyterlite.readthedocs.io/en/latest/howto/configure/config_files.html)
+to your JupyterLite deployment for build-time configuration and settings overrides.
+
+<!-- TODO: Run-time configuration via `jupyter-lite.json` not added yet here
+because I can't yet find a direct jupyter lite CLI mapping for that option -->
 
 ```python
-jupyterlite_config = "jupyterlite_config.json"
+# Build-time configuration for JupyterLite
+jupyterlite_config = "jupyter_lite_config.json"
+# Override plugins and extension settings
+jupyterlite_overrides = "overrides.json"
 ```
 
 ## Strip particular tagged cells from IPython Notebooks

--- a/docs/sample_overrides.json
+++ b/docs/sample_overrides.json
@@ -1,0 +1,20 @@
+{
+  "@jupyterlab/notebook-extension:panel": {
+    "toolbar": [
+      {
+        "name": "download",
+        "label": "Download",
+        "args": {},
+        "command": "docmanager:download",
+        "icon": "ui-components:download",
+        "rank": 50
+      }
+    ]
+  },
+  "@jupyterlab/apputils-extension:themes": {
+    "theme": "JupyterLab Christmas"
+  },
+  "@jupyter-notebook/application-extension:top": {
+    "visible": "no"
+  }
+}


### PR DESCRIPTION
## Description

This PR introduces a configuration option in `conf.py` called `jupyterlite_overrides`. This option modifies the command used to build JupyterLite internally within `jupyterlite-sphinx` to use a user-provided `overrides.json` file.

## Rationale

- It is currently possible to leave an `overrides.json` file in the `docs/` directory, similar to [`ipycanvas`'s documentation](https://github.com/jupyter-widgets-contrib/ipycanvas/blob/7226d36cc05e0f15b03af673510ed3e0f3cda424/docs/overrides.json), which will automatically be picked up by `jupyterlite-sphinx` (and thereby JupyterLite) when building the JupyterLite site.
- However, projects using `jupyterlite-sphinx` can benefit from the flexibility of using a custom override file with the docs, which is possible if one has access to the JupyterLite build command with ease.
This option is already available via https://jupyterlite-sphinx.readthedocs.io/en/latest/configuration.html#additional-cli-arguments-for-jupyter-lite-build, which was established via #169. Still, that approach has been directed mostly towards advanced users, and having this feature exposed through a configuration option similar to one for a build-time configuration file would make it easier to use and make it more visible with the rest of the options in the docs.

## Additional context

Please see https://github.com/jupyterlite/jupyterlite/issues/385#issuecomment-2536286348, which is where I got this idea. Some possible use cases for this can be:
- to be able to add download buttons for interactive notebooks within SciPy and PyWavelets that have been/are being established via https://github.com/scipy/scipy/pull/20303/ (cc: @melissawm) and https://github.com/PyWavelets/pywt/pull/741
- customise themes based on the surrounding theme of the page (dark or light – not sure how to switch it yet, but we do have an open issue about it: #124).
