### PR TITLE
Bump OS image and dependencies for Read the Docs build config

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,7 +1,7 @@
 version: 2
 
 build:
-  os: "ubuntu-20.04"
+  os: "ubuntu-22.04"
   tools:
     python: "mambaforge-4.10"
 

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -3,7 +3,7 @@ version: 2
 build:
   os: "ubuntu-22.04"
   tools:
-    python: "mambaforge-4.10"
+    python: "mambaforge-23.11"
 
 conda:
   environment: dev-environment.yml


### PR DESCRIPTION
## Description

Our Read the Docs configuration is slightly outdated by now, so I've updated the following:
- the OS version from Ubuntu 20.04 to Ubuntu 22.04
- the Mambaforge version from 4.10 to 23.11