### PR TITLE
Switch to Miniforge and drop Mambaforge

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,7 +32,7 @@ jobs:
         activate-environment: jupyterlite-sphinx
         environment-file: dev-environment.yml
         python-version: ${{ matrix.python-version }}
-        miniforge-variant: Mambaforge
+        miniforge-variant: Miniforge
         miniforge-version: latest
         auto-activate-base: false
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,7 +32,6 @@ jobs:
         activate-environment: jupyterlite-sphinx
         environment-file: dev-environment.yml
         python-version: ${{ matrix.python-version }}
-        miniforge-variant: Miniforge
         miniforge-version: latest
         auto-activate-base: false
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,10 +24,10 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Setup conda
-      uses: conda-incubator/setup-miniconda@v2
+      uses: conda-incubator/setup-miniconda@v3
       with:
         activate-environment: jupyterlite-sphinx
         environment-file: dev-environment.yml


### PR DESCRIPTION
## Description

CI runs are failing on the `main` branch and on recent PRs due to problems with setting `miniconda` up, this PR should fix the problem.

More descriptions here: https://conda-forge.org/news/2024/07/29/sunsetting-mambaforge/

## Changes made

- Bumped to `actions/checkout@v4` and `setup/miniconda@v3`
- Switched to Miniforge since the installer is identical

## Additional information

I feel adding a Dependabot file for GitHub Actions, and pinning the actions to their hashes would make sense as well, even if we set the update schedule to monthly.