### PR TITLE
Add some spacing below the Lite iframes

### DIFF
--- a/jupyterlite_sphinx/jupyterlite_sphinx.css
+++ b/jupyterlite_sphinx/jupyterlite_sphinx.css
@@ -12,6 +12,7 @@
   position: relative;
   cursor: pointer;
   box-shadow: 0 0.2rem 0.5rem #d8d8d8;
+  margin-bottom: 1.5rem;
 }
 
 .jupyterlite_sphinx_iframe {


### PR DESCRIPTION
## Description

Adds some spacing for the `jupyterlite_sphinx_iframe_container` class. The previous design can be viewed at #232.

> [!TIP]
> Try it at: https://jupyterlite-sphinx--235.org.readthedocs.build/en/235/directives/replite.html