### PR TITLE
Add missing dependency on `jupytext`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "jupyter_server",
     "jupyterlab_server",
     "jupyterlite-core >=0.2,<0.5",
+    "jupytext",
     "nbformat",
     "sphinx>=4",
 ]
@@ -30,7 +31,6 @@ docs = [
     "myst_parser",
     "pydata-sphinx-theme",
     "jupyterlite-xeus>=0.1.8,<0.3.0",
-    "jupytext",
 ]
 
 [tool.hatch.version]


### PR DESCRIPTION
## Description

The 0.17.0 release added `jupytext` via #221 as a dependency, but it was added in `[docs]` but not here – which means that `jupyterlite-sphinx` will fail on import (see https://github.com/conda-forge/jupyterlite-sphinx-feedstock/pull/37).

This PR corrects it (my apologies!) and adds it as a default dependency instead. I think the reason I added it to an optional dependency was that I was going to plan it as an optional dependency under an experimental flag, but we didn't have a discussion about it later.