### PR TITLE
Relax `jupyterlite-core` and `jupyterlite-xeus` dependencies

### DIFF
--- a/dev-environment.yml
+++ b/dev-environment.yml
@@ -5,7 +5,7 @@ dependencies:
     - pip
     - jupyter_server
     - jupyterlab_server
-    - jupyterlite-core >=0.3,<0.4
+    - jupyterlite-core >=0.3,<0.6
     - jupytext
     - pydata-sphinx-theme
     - micromamba
@@ -16,4 +16,4 @@ dependencies:
     - voici
     - pip:
         - .
-        - jupyterlite-xeus >=0.2.0a0
+        - jupyterlite-xeus >=2.1.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     "docutils",
     "jupyter_server",
     "jupyterlab_server",
-    "jupyterlite-core >=0.2,<0.5",
+    "jupyterlite-core >=0.2,<0.6",
     "jupytext",
     "nbformat",
     "sphinx>=4",
@@ -30,7 +30,7 @@ dev = [
 docs = [
     "myst_parser",
     "pydata-sphinx-theme",
-    "jupyterlite-xeus>=0.1.8,<0.3.0",
+    "jupyterlite-xeus>=0.1.8,<4",
 ]
 
 [tool.hatch.version]


### PR DESCRIPTION
Allow for newer versions of  `jupyterlite-core` and `jupyterlite-xeus` , which should be compatible with `jupyterlite-sphinx`.