### PR TITLE
Drop Python 3.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 description = "Sphinx extension for deploying JupyterLite"
 readme = "README.md"
 license = { file = "LICENSE" }
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 authors = [
     { name = "JupyterLite Contributors" },
 ]


### PR DESCRIPTION
Since Python 3.8 is now EOL.