### PR TITLE
Allow enabling/disabling REPL code execution in the `Replite` directive

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -87,7 +87,7 @@ to the directive. Note that this is compatible only if `:new_tab:` is also provi
 
 ## REPL code auto-execution with the `Replite` directive
 
-It is possible to control whether code snippets in REPL environments automatically executeswhen loaded.
+It is possible to control whether code snippets in REPL environments automatically executes when loaded.
 For this, you may set `replite_auto_execute = False` globally in `conf.py` with  (defaults to `True` if
 not present), or override it on a per-directive basis  with `:execute: true` or `:execute: false`.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -85,6 +85,12 @@ voici_new_tab_button_text = "My custom Voici button text"
 You can override this text on a per-directive basis by passing the `:new_tab_button_text:` option
 to the directive. Note that this is compatible only if `:new_tab:` is also provided.
 
+## REPL code auto-execution with the `Replite` directive
+
+It is possible to control whether code snippets in REPL environments automatically executeswhen loaded.
+For this, you may set `replite_auto_execute = False` globally in `conf.py` with  (defaults to `True` if
+not present), or override it on a per-directive basis  with `:execute: true` or `:execute: false`.
+
 ## Strip particular tagged cells from IPython Notebooks
 
 When using the `NotebookLite`, `JupyterLite`, or `Voici` directives with a notebook passed to them, you can

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -89,7 +89,7 @@ to the directive. Note that this is compatible only if `:new_tab:` is also provi
 
 It is possible to control whether code snippets in REPL environments automatically executes when loaded.
 For this, you may set `replite_auto_execute = False` globally in `conf.py` with  (defaults to `True` if
-not present), or override it on a per-directive basis  with `:execute: true` or `:execute: false`.
+not present), or override it on a per-directive basis  with `:execute: True` or `:execute: False`.
 
 ## Strip particular tagged cells from IPython Notebooks
 

--- a/docs/directives/replite.md
+++ b/docs/directives/replite.md
@@ -110,3 +110,44 @@ global value using an additional `:new_tab_button_text:` parameter:
    ax.plot(x, y)
    plt.show()
 ```
+
+It is also possible to disable the execution of the code in the Replite console by setting the `:execute:` option to `False`:
+
+```rst
+.. replite::
+   :kernel: xeus-python
+   :new_tab: True # False works too
+   :new_tab_button_text: Open REPL with the code execution disabled
+   :execute: False
+
+   import matplotlib.pyplot as plt
+   import numpy as np
+
+   x = np.linspace(0, 2 * np.pi, 200)
+   y = np.sin(x)
+
+   fig, ax = plt.subplots()
+   ax.plot(x, y)
+   plt.show()
+```
+
+```{eval-rst}
+.. replite::
+   :kernel: xeus-python
+   :new_tab: True # False works too
+   :new_tab_button_text: Open REPL with the code execution disabled
+   :execute: False
+
+   import matplotlib.pyplot as plt
+   import numpy as np
+
+   x = np.linspace(0, 2 * np.pi, 200)
+   y = np.sin(x)
+
+   fig, ax = plt.subplots()
+   ax.plot(x, y)
+   plt.show()
+```
+
+The behaviour can also be [configured globally](../configuration.md#replite-auto-execution-with-the-replite-directive)
+and then overridden in individual directives.

--- a/docs/directives/replite.md
+++ b/docs/directives/replite.md
@@ -111,7 +111,14 @@ global value using an additional `:new_tab_button_text:` parameter:
    plt.show()
 ```
 
-It is also possible to disable the execution of the code in the Replite console by setting the `:execute:` option to `False`:
+````{tip}
+
+   With `jupyterlite-core` **versions 0.5.0 and later**, it is also possible to disable the execution of
+   the code in the Replite console by setting the `:execute:` option to `False`. This option defaults to `True`,
+   and setting it has no effect in versions prior to 0.5.0.
+
+   The behaviour can also be [configured globally](../configuration.md#replite-auto-execution-with-the-replite-directive)
+   and then overridden in individual directives as needed.
 
 ```rst
 .. replite::
@@ -149,5 +156,4 @@ It is also possible to disable the execution of the code in the Replite console 
    plt.show()
 ```
 
-The behaviour can also be [configured globally](../configuration.md#replite-auto-execution-with-the-replite-directive)
-and then overridden in individual directives.
+````

--- a/jupyterlite_sphinx/jupyterlite_sphinx.py
+++ b/jupyterlite_sphinx/jupyterlite_sphinx.py
@@ -269,6 +269,9 @@ class RepliteTab(Element):
             code = "\n".join(code_lines)
             lite_options["code"] = code
 
+        if "execute" in lite_options and lite_options["execute"] == "0":
+            lite_options["execute"] = "0"
+
         app_path = self.lite_app
         if notebook is not None:
             lite_options["path"] = notebook
@@ -401,6 +404,7 @@ class RepliteDirective(SphinxDirective):
         "width": directives.unchanged,
         "height": directives.unchanged,
         "kernel": directives.unchanged,
+        "execute": directives.unchanged,
         "toolbar": directives.unchanged,
         "theme": directives.unchanged,
         "prompt": directives.unchanged,
@@ -420,6 +424,17 @@ class RepliteDirective(SphinxDirective):
         search_params = search_params_parser(self.options.pop("search_params", False))
 
         new_tab = self.options.pop("new_tab", False)
+
+        # We first check the global config, and then the per-directive
+        # option. It defaults to true for backwards compatibility.
+        execute = self.options.pop("execute", None)
+        if execute is None:
+            execute = str(self.env.config.replite_auto_execute).lower()
+        else:
+            execute = execute.lower()
+
+        if execute == "false":
+            self.options["execute"] = "0"
 
         content = self.content
 
@@ -1155,6 +1170,7 @@ def setup(app):
         man=(skip, None),
     )
     app.add_directive("replite", RepliteDirective)
+    app.add_config_value("replite_auto_execute", True, rebuild="html")
 
     # Initialize Voici directive and tabbed interface
     app.add_node(

--- a/jupyterlite_sphinx/jupyterlite_sphinx.py
+++ b/jupyterlite_sphinx/jupyterlite_sphinx.py
@@ -423,17 +423,14 @@ class RepliteDirective(SphinxDirective):
 
         search_params = search_params_parser(self.options.pop("search_params", False))
 
-        new_tab = self.options.pop("new_tab", False)
-
         # We first check the global config, and then the per-directive
-        # option. It defaults to true for backwards compatibility.
-        execute = self.options.pop("execute", None)
-        if execute is None:
-            execute = str(self.env.config.replite_auto_execute).lower()
-        else:
-            execute = execute.lower()
+        # option. It defaults to True for backwards compatibility.
+        execute = self.options.pop("execute", str(self.env.config.replite_auto_execute))
 
-        if execute == "false":
+        if execute not in ("True", "False"):
+            raise ValueError("The :execute: option must be either True or False")
+
+        if execute == "False":
             self.options["execute"] = "0"
 
         content = self.content
@@ -444,6 +441,8 @@ class RepliteDirective(SphinxDirective):
             os.path.join(self.env.app.srcdir, JUPYTERLITE_DIR),
             os.path.dirname(self.get_source_info()[0]),
         )
+
+        new_tab = self.options.pop("new_tab", False)
 
         if new_tab:
             directive_button_text = self.options.pop("new_tab_button_text", None)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,9 @@ dependencies = [
     "docutils",
     "jupyter_server",
     "jupyterlab_server",
-    "jupyterlite-core >=0.2,<0.6",
+    # temporary: for trying out no-code-run REPL.
+    # wait for 0.5.0 stable release
+    "jupyterlite-core==0.5.0b0",
     "jupytext",
     "nbformat",
     "sphinx>=4",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,9 +16,7 @@ dependencies = [
     "docutils",
     "jupyter_server",
     "jupyterlab_server",
-    # temporary: for trying out no-code-run REPL.
-    # wait for 0.5.0 stable release
-    "jupyterlite-core==0.5.0b0",
+    "jupyterlite-core >=0.2,<0.6",
     "jupytext",
     "nbformat",
     "sphinx>=4",


### PR DESCRIPTION
## Description

This pull request exposes functionality added upstream via https://github.com/jupyterlite/jupyterlite/pull/1547 and released in [`jupyterlite-core` version `0.5.0`](https://github.com/jupyterlite/jupyterlite/releases/tag/v0.5.0).

In particular, this enables the act of enabling/disabling the code execution for the `Replite` directive, so it is now possible for the REPL not to load the Pyodide kernel automatically and instead wait for the user's input. It can be controlled via the `replite_auto_execute` option globally or via the `:execute: [True/False]` option on a per-directive basis as an override. This appends `&execute=0` to the REPL URL if `False`.

It is to be noted that while we support `jupyterlite-core >=0.2,<0.6` via #238, this option requires `jupyterlite >= 0.5` to work, and there is no effect for versions prior to `jupyterlite-core` 0.5.

Closes #244

## Changes made

- The addition of a `replite_auto_execute` global configuration option, an `:execute:` option for the Replite directive, and corresponding URL handling
- Both options documented for readers

## Additional context

This will help us make progress on https://github.com/matplotlib/matplotlib/pull/22634