### PR TITLE
Better mobile device detection for interactive examples buttons

### DIFF
--- a/jupyterlite_sphinx/jupyterlite_sphinx.css
+++ b/jupyterlite_sphinx/jupyterlite_sphinx.css
@@ -67,12 +67,3 @@
     transform: rotate(1turn);
   }
 }
-
-/* we do not want the button to show on smaller screens (phones), as clicking
- * can download a lot of data. 480px is a commonly used breakpoint to identify if a device is a smartphone.  */
-
-@media (max-width: 480px), (max-height: 480px) {
-  div.try_examples_button_container {
-    display: none;
-  }
-}

--- a/jupyterlite_sphinx/jupyterlite_sphinx.js
+++ b/jupyterlite_sphinx/jupyterlite_sphinx.js
@@ -149,6 +149,42 @@ var tryExamplesGlobalMinHeight = 0;
  */
 var tryExamplesConfigLoaded = false;
 
+// This function is used to check if the current device is a mobile device.
+// We assume the authenticity of the user agent string is enough to
+// determine that, and we also check the window size as a fallback.
+window.isMobileDevice = () => {
+  const mobilePatterns = [
+    /Android/i,
+    /webOS/i,
+    /iPhone/i,
+    /iPad/i,
+    /iPod/i,
+    /BlackBerry/i,
+    /IEMobile/i,
+    /Windows Phone/i,
+    /Opera Mini/i,
+    /SamsungBrowser/i,
+    /UC.*Browser|UCWEB/i,
+    /MiuiBrowser/i,
+    /Mobile/i,
+    /Tablet/i,
+  ];
+
+  const isMobileByUA = mobilePatterns.some((pattern) =>
+    pattern.test(navigator.userAgent),
+  );
+  const isMobileBySize = window.innerWidth <= 480 || window.innerHeight <= 480;
+  const isLikelyMobile = isMobileByUA || isMobileBySize;
+
+  if (isLikelyMobile) {
+    console.log(
+      "Mobile device detected, disabling interactive example buttons to conserve bandwidth.",
+    );
+  }
+
+  return isLikelyMobile;
+};
+
 // A config loader with improved error handling + request deduplication
 const ConfigLoader = (() => {
   // setting a private state for managing requests and errors
@@ -173,6 +209,15 @@ const ConfigLoader = (() => {
   };
 
   const loadConfig = async (configFilePath) => {
+    if (window.isMobileDevice()) {
+      const buttons = document.getElementsByClassName("try_examples_button");
+      for (let i = 0; i < buttons.length; i++) {
+        buttons[i].classList.add("hidden");
+      }
+      tryExamplesConfigLoaded = true; // mock it
+      return;
+    }
+
     if (tryExamplesConfigLoaded) {
       return;
     }
@@ -253,6 +298,27 @@ const ConfigLoader = (() => {
     },
   };
 })();
+
+// Add a resize handler that will update the buttons' visibility on
+// orientation changes
+let resizeTimeout;
+window.addEventListener("resize", () => {
+  clearTimeout(resizeTimeout);
+  resizeTimeout = setTimeout(() => {
+    if (!tryExamplesConfigLoaded) return; // since we won't interfere if the config isn't loaded
+
+    const buttons = document.getElementsByClassName("try_examples_button");
+    const shouldHide = window.isMobileDevice();
+
+    for (let i = 0; i < buttons.length; i++) {
+      if (shouldHide) {
+        buttons[i].classList.add("hidden");
+      } else {
+        buttons[i].classList.remove("hidden");
+      }
+    }
+  }, 250);
+});
 
 window.loadTryExamplesConfig = ConfigLoader.loadConfig;
 

--- a/jupyterlite_sphinx/jupyterlite_sphinx.js
+++ b/jupyterlite_sphinx/jupyterlite_sphinx.js
@@ -149,7 +149,7 @@ var tryExamplesGlobalMinHeight = 0;
  */
 var tryExamplesConfigLoaded = false;
 
-// A config loader with imprved error handling + request deduplication
+// A config loader with improved error handling + request deduplication
 const ConfigLoader = (() => {
   // setting a private state for managing requests and errors
   let configLoadPromise = null;


### PR DESCRIPTION
## Description

> [!TIP]
> This PR builds on top of changes from #249 in order to ease merge conflicts. Please view the changes in commit f1bb4eaae483788012050b28760d7c3f8834fc58 for a better diff in the meantime.

This PR closes #140; it moves the logic from the CSS styles for disabling the interactive buttons and uses a better heuristic via our JavaScript code; i.e., the `navigator.userAgent`'s value to check what sort of device a user is on. As a fallback, the screen size check has also been kept. A resize handler with 250ms debouncing has also been added here to check the screen size if the buttons haven't been disabled already.

This keeps them enabled on devices like iPads and other tablets.

cc: @gabalafou