### PR TITLE
Add the "See Also" section to the `TryExamples` directive's trailing section ignore patterns

### DIFF
--- a/jupyterlite_sphinx/_try_examples.py
+++ b/jupyterlite_sphinx/_try_examples.py
@@ -303,6 +303,28 @@ _non_example_docstring_section_headers = (
     "Yields",
 )
 
+# Sourced from docutils.parsers.rst.directives._directive_registry.keys()
+# and from https://docutils.sourceforge.io/docs/ref/rst/directives.html
+# We hardcode a subset of this list as there is no public API in docutils
+# or Sphinx to get this information directly.
+# See https://docutils.sourceforge.io/docs/ref/rst/directives.html
+#
+# This subset is only a list of sensible defaults and widely used directives
+# based on our discretion that can signify the start of a new section in a
+# docstring and is not meant to be exhaustive.
+_irrelevant_directives = [
+    "class",
+    "contents",
+    "epigraph",
+    "footer",
+    "header",
+    "highlights",
+    "parsed-literal",
+    "pull-quote",
+    "seealso",
+    "sidebar",
+    "topic",
+]
 
 _examples_start_pattern = re.compile(r".. (rubric|admonition):: Examples")
 _next_section_pattern = re.compile(
@@ -315,10 +337,10 @@ _next_section_pattern = re.compile(
         + [r"\!\! processed by numpydoc \!\!"]
         # Attributes section sometimes has no directive.
         + [r":Attributes:"]
-        # The See Also section shows up for old numpydoc versions such as that
-        # of SymPy where it is accounted for as an admonition and not a rubric,
-        # therefore we check for it as a special case for now.
-        + [r"\.\. seealso::"]
+        # Directives that can start a new section in a docstring and are
+        # not handled by numpydoc in terms of reordering. Noticed in SymPy
+        # as it does not use modern numpydoc at the time of writing.
+        + [rf"\.\. ({directive})::" for directive in _irrelevant_directives]
     )
 )
 

--- a/jupyterlite_sphinx/_try_examples.py
+++ b/jupyterlite_sphinx/_try_examples.py
@@ -315,9 +315,9 @@ _next_section_pattern = re.compile(
         + [r"\!\! processed by numpydoc \!\!"]
         # Attributes section sometimes has no directive.
         + [r":Attributes:"]
-        # The See Also section shows up for old numpydoc versions where ordering
-        # is neither guaranteed nor enforced; such as SymPy, therefore we check
-        # for it as a special case.
+        # The See Also section shows up for old numpydoc versions such as that
+        # of SymPy where it is accounted for as an admonition and not a rubric,
+        # therefore we check for it as a special case for now.
         + [r"\.\. seealso::"]
     )
 )

--- a/jupyterlite_sphinx/_try_examples.py
+++ b/jupyterlite_sphinx/_try_examples.py
@@ -315,9 +315,12 @@ _next_section_pattern = re.compile(
         + [r"\!\! processed by numpydoc \!\!"]
         # Attributes section sometimes has no directive.
         + [r":Attributes:"]
-        # The See Also section shows up for old numpydoc versions such as that
-        # of SymPy where it is accounted for as an admonition and not a rubric,
-        # therefore we check for it as a special case for now.
+        # The See Also section is also a heading that needs to be escaped. This
+        # showed up in the SymPy documentation which used an older version of
+        # numpydoc that did not enforce ordering, and modern numpydoc did, hence
+        # it was not noticed. For future reference, see:
+        # https://github.com/jupyterlite/jupyterlite-sphinx/pull/251
+        # https://github.com/sympy/sympy/pull/27419
         + [r"\.\. seealso::"]
     )
 )

--- a/jupyterlite_sphinx/_try_examples.py
+++ b/jupyterlite_sphinx/_try_examples.py
@@ -315,6 +315,10 @@ _next_section_pattern = re.compile(
         + [r"\!\! processed by numpydoc \!\!"]
         # Attributes section sometimes has no directive.
         + [r":Attributes:"]
+        # The See Also section shows up for old numpydoc versions where ordering
+        # is neither guaranteed nor enforced; such as SymPy, therefore we check
+        # for it as a special case.
+        + [r".. seealso::"]
     )
 )
 

--- a/jupyterlite_sphinx/_try_examples.py
+++ b/jupyterlite_sphinx/_try_examples.py
@@ -303,28 +303,6 @@ _non_example_docstring_section_headers = (
     "Yields",
 )
 
-# Sourced from docutils.parsers.rst.directives._directive_registry.keys()
-# and from https://docutils.sourceforge.io/docs/ref/rst/directives.html
-# We hardcode a subset of this list as there is no public API in docutils
-# or Sphinx to get this information directly.
-# See https://docutils.sourceforge.io/docs/ref/rst/directives.html
-#
-# This subset is only a list of sensible defaults and widely used directives
-# based on our discretion that can signify the start of a new section in a
-# docstring and is not meant to be exhaustive.
-_irrelevant_directives = [
-    "class",
-    "contents",
-    "epigraph",
-    "footer",
-    "header",
-    "highlights",
-    "parsed-literal",
-    "pull-quote",
-    "seealso",
-    "sidebar",
-    "topic",
-]
 
 _examples_start_pattern = re.compile(r".. (rubric|admonition):: Examples")
 _next_section_pattern = re.compile(
@@ -337,10 +315,10 @@ _next_section_pattern = re.compile(
         + [r"\!\! processed by numpydoc \!\!"]
         # Attributes section sometimes has no directive.
         + [r":Attributes:"]
-        # Directives that can start a new section in a docstring and are
-        # not handled by numpydoc in terms of reordering. Noticed in SymPy
-        # as it does not use modern numpydoc at the time of writing.
-        + [rf"\.\. ({directive})::" for directive in _irrelevant_directives]
+        # The See Also section shows up for old numpydoc versions such as that
+        # of SymPy where it is accounted for as an admonition and not a rubric,
+        # therefore we check for it as a special case for now.
+        + [r"\.\. seealso::"]
     )
 )
 

--- a/jupyterlite_sphinx/_try_examples.py
+++ b/jupyterlite_sphinx/_try_examples.py
@@ -308,7 +308,7 @@ _examples_start_pattern = re.compile(r".. (rubric|admonition):: Examples")
 _next_section_pattern = re.compile(
     "|".join(
         [
-            rf".. (rubric|admonition)::\s*{header}"
+            rf"\.\. (rubric|admonition)::\s*{header}"
             for header in _non_example_docstring_section_headers
         ]
         # If examples section is last, processed by numpydoc may appear at end.
@@ -318,7 +318,7 @@ _next_section_pattern = re.compile(
         # The See Also section shows up for old numpydoc versions where ordering
         # is neither guaranteed nor enforced; such as SymPy, therefore we check
         # for it as a special case.
-        + [r".. seealso::"]
+        + [r"\.\. seealso::"]
     )
 )
 

--- a/jupyterlite_sphinx/_try_examples.py
+++ b/jupyterlite_sphinx/_try_examples.py
@@ -315,12 +315,8 @@ _next_section_pattern = re.compile(
         + [r"\!\! processed by numpydoc \!\!"]
         # Attributes section sometimes has no directive.
         + [r":Attributes:"]
-        # The See Also section is also a heading that needs to be escaped. This
-        # showed up in the SymPy documentation which used an older version of
-        # numpydoc that did not enforce ordering, and modern numpydoc did, hence
-        # it was not noticed. For future reference, see:
-        # https://github.com/jupyterlite/jupyterlite-sphinx/pull/251
-        # https://github.com/sympy/sympy/pull/27419
+        # See Also sections are mapped to Sphinx's `.. seealso::` directive,
+        # not admonitions or rubrics.
         + [r"\.\. seealso::"]
     )
 )


### PR DESCRIPTION
## Description

This PR is a bug fix for a problem I noticed in sympy/sympy#27419. [SymPy uses a vendored version of `numpydoc`](https://github.com/sympy/sympy/blob/3c33a8283cd02e2e012b57435bd6212ed915a0bc/doc/ext/numpydoc.py) that was added twelve years back based on https://github.com/numpy/numpydoc; both have diverged in implementation and complexity since then, and SymPy's `numpydoc` doesn't enforce a particular order for each section, unlike the current `numpydoc`, which can automatically order/reorder sections. This causes the following behaviour:

<details>
<summary>Tap to show "Before"</summary>

<br>

<img width="1512" alt="The image shows the documentation page for SymPy 1.14.dev's number theory module, specifically documenting the sympy.ntheory.factor_.multiplicity(p, n) function. The page features a green snake-wrapped-S logo and a dark green sidebar with navigation sections. The main content includes function documentation and an interactive JupyterLite notebook example showing function usage. Notably, the notebook contains an extra erroneous or rather misplaced 'seealso' section with :obj:~.trailing'` appended at the bottom, which appears to be a documentation artifact that shouldn't be part of the interactive example. The page also includes proper 'See also' references at the top linking to 'factorint' and 'smoothness' functions, and a right sidebar showing the 'Ntheory Class Reference' and related functions." src="https://github.com/user-attachments/assets/dcb75938-1f45-4644-9b4b-8c8c717207ec" />

<br>

</details>

where the See Also section percolates into the notebook. With this fix in place applied, we have

<details>
<summary>Tap to show "After"</summary>

<br>

<img width="1512" alt="The image shows the documentation page for SymPy 1.14.dev's number theory module, specifically documenting the sympy.ntheory.factor_.multiplicity(p, n) function. The page features a green snake-wrapped-S logo and a dark green sidebar with navigation sections. The main content includes function documentation and an interactive JupyterLite notebook example showing function usage. Unlike the previous version noted above, this notebook correctly does not contain the erroneous 'seealso' section at the bottom, showing the proper behaviour. The page maintains its standard 'See also' references at the top linking to 'factorint' and 'smoothness' functions, and includes a right sidebar showing the 'Ntheory Class Reference' and related functions." src="https://github.com/user-attachments/assets/91d5500e-1096-4d6c-ab04-506ae779bf71" />

<br>

</details>

where the section no longer appears in the notebook, and we stop at the end of the Examples section, as intended.

## Additional context

It would be nice to update the SymPy documentation infrastructure to use the latest `numpydoc` so that the documentation is consistent with that for other packages. However, considering that its custom `numpydoc` has had multiple stylistic deviations by now, I've left it to be a follow-up task for me after the PR linked above gets merged. So, supporting SymPy in a special case in this manner doesn't sound too bad to me, considering that this change is trivial.
