### PR TITLE
Update documentation around fullscreen usage of `jupyterlite-sphinx` apps

### DIFF
--- a/docs/full.md
+++ b/docs/full.md
@@ -24,4 +24,4 @@ If you want to add code to the REPL for execution, you can use the `code` URL pa
 
 Info on more configuration options is available in the [REPL documentation](https://jupyterlite.readthedocs.io/en/stable/quickstart/embed-repl.html#configuration).
 
-Please see the documentation for individual options for each directive and [global configuration options](configuration.md)  for more information.
+Please see the documentation for individual options for each directive and [global configuration options](configuration.md) for more information.

--- a/docs/full.md
+++ b/docs/full.md
@@ -1,17 +1,26 @@
 # Fullscreen access
 
-Once and JupyterLite example has been activate by a user, and "Open in Tab" button is available that will open the same
+Once a JupyterLite example gets activated by a user, an "Open in Tab" button becomes available, which will open the same
 JupyterLite instance in a separate tab.
 
-## custom link to JupyterLite
+## Custom links to JupyterLite apps
 
-You can access the JupyterLite deployment that `jupyterlite-sphinx` made for you, in fullscreen, following the `./lite/lab` and `./lite/retro` relative urls:
+You can access the JupyterLite app that `jupyterlite-sphinx` made for you, in fullscreen, using the following links:
 
-```{eval-rst}
+- [JupyterLab](lite/lab/index.html)
+- [Notebook](lite/tree/index.html)
+- [REPL](lite/repl/index.html)
+- [Voici](lite/voici/index.html)
 
-- `JupyterLab <lite/lab/index.html>`_
-- `Notebook <lite/tree/index.html>`_
+## Tips for handling URLs
 
-```
+If you want to open a specific notebook in fullscreen JupyterLab/Notebook/Voici, you can use the `path` URL parameter, e.g. 
 
-If you want to open a specific notebook in fullscreen JupyterLab/Notebook, you can use the `path` URL parameter, e.g. `./lite/lab/index.html?path=my_noteboook.ipynb`.
+- `./lite/lab/index.html?path=my_noteboook.ipynb` for Lab
+- `./lite/notebooks/index.html?path=my_notebook.ipynb` for Notebook
+- `./lite/voici/render/my_notebook.html` for Voici
+
+If you want to add code to the REPL for execution, you can use the `code` URL parameter, e.g. `./lite/repl/index.html?code=print("Hello, world!")`. You may also use `&execute=0` to prevent the code from being executed until you press Enter.
+More configuration options are available with the [REPL documentation](https://jupyterlite.readthedocs.io/en/stable/quickstart/embed-repl.html#configuration)
+
+Please see the documentation individual options and global [Configuration](configuration.md) options for more information.

--- a/docs/full.md
+++ b/docs/full.md
@@ -22,6 +22,6 @@ If you want to open a specific notebook in fullscreen JupyterLab/Notebook/Voici,
 
 If you want to add code to the REPL for execution, you can use the `code` URL parameter, e.g. `./lite/repl/index.html?code=print("Hello, world!")`. You may also use `&execute=0` to prevent the code from being executed until you press Enter.
 
-More configuration options are available with the [REPL documentation](https://jupyterlite.readthedocs.io/en/stable/quickstart/embed-repl.html#configuration)
+More configuration options are available with the [REPL documentation](https://jupyterlite.readthedocs.io/en/stable/quickstart/embed-repl.html#configuration).
 
 Please see the documentation for individual options for each directive and [global configuration options](configuration.md)  for more information.

--- a/docs/full.md
+++ b/docs/full.md
@@ -16,11 +16,12 @@ You can access the JupyterLite app that `jupyterlite-sphinx` made for you, in fu
 
 If you want to open a specific notebook in fullscreen JupyterLab/Notebook/Voici, you can use the `path` URL parameter, e.g. 
 
-- `./lite/lab/index.html?path=my_noteboook.ipynb` for Lab
+- `./lite/lab/index.html?path=my_notebook.ipynb` for Lab
 - `./lite/notebooks/index.html?path=my_notebook.ipynb` for Notebook
 - `./lite/voici/render/my_notebook.html` for Voici
 
 If you want to add code to the REPL for execution, you can use the `code` URL parameter, e.g. `./lite/repl/index.html?code=print("Hello, world!")`. You may also use `&execute=0` to prevent the code from being executed until you press Enter.
+
 More configuration options are available with the [REPL documentation](https://jupyterlite.readthedocs.io/en/stable/quickstart/embed-repl.html#configuration)
 
-Please see the documentation individual options and global [Configuration](configuration.md) options for more information.
+Please see the documentation for individual options for each directive and [global configuration options](configuration.md)  for more information.

--- a/docs/full.md
+++ b/docs/full.md
@@ -5,7 +5,7 @@ JupyterLite instance in a separate tab.
 
 ## Custom links to JupyterLite apps
 
-You can access the JupyterLite app that `jupyterlite-sphinx` made for you, in fullscreen, using the following links:
+You can access the JupyterLite apps that `jupyterlite-sphinx` deployed for you, in fullscreen, using the following links:
 
 - [JupyterLab](lite/lab/index.html)
 - [Notebook](lite/tree/index.html)

--- a/docs/full.md
+++ b/docs/full.md
@@ -22,6 +22,6 @@ If you want to open a specific notebook in fullscreen JupyterLab/Notebook/Voici,
 
 If you want to add code to the REPL for execution, you can use the `code` URL parameter, e.g. `./lite/repl/index.html?code=print("Hello, world!")`. You may also use `&execute=0` to prevent the code from being executed until you press Enter.
 
-More configuration options are available with the [REPL documentation](https://jupyterlite.readthedocs.io/en/stable/quickstart/embed-repl.html#configuration).
+Info on more configuration options is available in the [REPL documentation](https://jupyterlite.readthedocs.io/en/stable/quickstart/embed-repl.html#configuration).
 
 Please see the documentation for individual options for each directive and [global configuration options](configuration.md)  for more information.


### PR DESCRIPTION
## Description

This PR makes some documentation updates. In specific:

- some grammatical errors have been fixed
- updated headings
- added missing links to REPL and Voici apps running in fullscreen
- added tips on how to open a notebook by specifying its path for the JupyterLite/Notebook/Voici apps' URLs
- added a small note on customising the REPL with a link to the REPL's complete documentation in JupyterLite upstream