### PR TITLE
Change button text contrast to comply with WCAG AA

### DIFF
--- a/docs/_static/try_examples.css
+++ b/docs/_static/try_examples.css
@@ -11,6 +11,7 @@
   font-family: vibur;
   font-size: larger;
   box-shadow: 0 2px 5px rgba(108, 108, 108, 0.2);
+  color: black;
 }
 
 .try_examples_button:hover {
@@ -18,6 +19,7 @@
   transform: scale(1.02);
   box-shadow: 0 2px 5px rgba(0, 0, 0, 0.2);
   cursor: pointer;
+  color: white;
 }
 
 .try_examples_button_container {


### PR DESCRIPTION
Currently contrast of white-on-yellow is 1.34:1, but WCAG AA requires 4.5:1!


---

Separately, I expected the CSS for styling the button to be included with this extension, but the CSS seems to only be present in the docs of this extension. Is that intended, or should the CSS be bundled? 

![image](https://github.com/user-attachments/assets/992941ed-e8ae-472f-b914-4a08b379c493)

I got my docs page looking nice by copying the CSS over to my Sphinx custom CSS file.