### PR TITLE
BUG: Fix SciPy `make dist` doc workflow by ensuring jupyter is run with the current Python executable

### DIFF
--- a/jupyterlite_sphinx/jupyterlite_sphinx.py
+++ b/jupyterlite_sphinx/jupyterlite_sphinx.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import json
 from uuid import uuid4
 import shutil
@@ -1006,6 +1007,8 @@ def jupyterlite_build(app: Sphinx, error):
             apps_option.extend(["--apps", "voici"])
 
         command = [
+            sys.executable,
+            "-m",
             "jupyter",
             "lite",
             "build",


### PR DESCRIPTION
This PR ensures jupyter is invoked with the current Python executable, so that if it is an executable from an unactivated virtual environment, things will still work.

While debugging https://github.com/scipy/scipy/issues/22241 I found that the `make dist` workflow used to build release docs for SciPy creates a clean virtual environment, installs dependencies in this virtual environment, and then invokes the documentation build like this:

```
	install -d build
	rm -rf build/env
	$(PYTHON) -mvenv --system-site-packages build/env
	$(CURDIR)/build/env/bin/python -mpip install -r ../requirements/doc.txt
	$(CURDIR)/build/env/bin/python -mpip install ..
	make PYTHON="$(CURDIR)/build/env/bin/python" doc-dist
```

So the Sphinx build is initiated with the Python from this clean virtual environment, but the virtual environment is never activated. It turns out that when `jupyter` is invoked from within `jupyterlite-sphinx` using `subprocess.run`, the virtual environment from the `make dist` build isn't used. It seems the docs were building fine, but the interactive docs were not working on my machine (Ubuntu 22.04) because a `jupyter` I'd inadvertently installed in the `--user` directory was being used instead, and this went unnoticed because the virtual environment is created with the `--system-site-packages` option.  I'm not sure if this may have also happened when @tylerjreddy was building the SciPy docs, but with the patch here, the SciPy interactive docs work correctly on my machine when using `make dist`.

