### PR TITLE
pin micromamba to v2.0.5 to fix failing RTD builds

### DIFF
--- a/dev-environment.yml
+++ b/dev-environment.yml
@@ -8,7 +8,7 @@ dependencies:
     - jupyterlite-core >=0.3,<0.6
     - jupytext
     - pydata-sphinx-theme
-    - micromamba
+    - micromamba=2.0.5
     - myst-parser
     - docutils
     - sphinx

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,7 +18,7 @@ strip_tagged_cells = True
 
 # Enable this to unsilence JupyterLite and aid debugging
 # within our own documentation.
-# jupyterlite_silence = False
+jupyterlite_silence = False
 
 master_doc = "index"
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,7 +18,7 @@ strip_tagged_cells = True
 
 # Enable this to unsilence JupyterLite and aid debugging
 # within our own documentation.
-jupyterlite_silence = False
+# jupyterlite_silence = False
 
 master_doc = "index"
 


### PR DESCRIPTION
This PR fixes #276. The pin should be temporary.