### PR TITLE
Fix incorrect disable marker for `TryExamples` buttons

### DIFF
--- a/docs/directives/try_examples.md
+++ b/docs/directives/try_examples.md
@@ -195,7 +195,7 @@ if needed. Adding the comment
 
 
 ```rst
-..! disable_try_examples`
+.. disable_try_examples
 ```
 
 as the first non-empty line under

--- a/jupyterlite_sphinx/_try_examples.py
+++ b/jupyterlite_sphinx/_try_examples.py
@@ -339,7 +339,7 @@ def insert_try_examples_directive(lines, **options):
     """Adds try_examples directive to Examples section of a docstring.
 
     Hack to allow for a config option to enable try_examples functionality
-    in all Examples sections (unless a comment "..! disable_try_examples" is
+    in all Examples sections (unless a comment ".. disable_try_examples" is
     added explicitly after the section header.)
 
 
@@ -354,7 +354,7 @@ def insert_try_examples_directive(lines, **options):
     list of str
         Updated version of the input docstring which has a try_examples directive
         inserted in the Examples section (if one exists) with all Examples content
-        indented beneath it. Does nothing if the comment "..! disable_try_examples"
+        indented beneath it. Does nothing if the comment ".. disable_try_examples"
         is included at the top of the Examples section. Also a no-op if the
         try_examples directive is already included.
     """
@@ -375,8 +375,8 @@ def insert_try_examples_directive(lines, **options):
         # Examples section had no content, no need to insert directive.
         return lines[:]
 
-    # Check for the "..! disable_try_examples" comment.
-    if lines[left_index].strip() == "..! disable_try_examples::":
+    # Check for the ".. disable_try_examples" comment.
+    if lines[left_index].strip() == ".. disable_try_examples":
         # If so, do not insert directive.
         return lines[:]
 


### PR DESCRIPTION
This is something I discovered as a part of working on jupyterlite/sphinx-demo#5. There were two problems with this marker:

1. The documentation was incorrect all this time; it pointed users to use `..! disable_try_examples`, when what is to be used here has been `..! disable_try_examples::` (i.e., with the two extra colons) like how we've been checking for it in the code
2. When this was used, it didn't actually remove the text from the rendered documentation and the `..! disable_try_examples::` text would show out of place in the HTML page.

~I have chosen to fix the documentation to match with the code here, rather than fixing the code to match with the documentation. My reason is that~ A code search result: https://github.com/search?q=%22..!+disable_try_examples%22&type=code reveals that this option hasn't been used at all in the wild (most users might be preferring to use `try_examples.json` instead). The only use of it is here: https://github.com/bg6mgd/d2py/blob/db460e7cc98f120c58658b352ebcc12392a383ae/doc/jupyter/jupyterlite/jupyterlite-sphinx/usages/directives/try_examples.md?plain=1#L166, which just looks like a translation of our documentation and not any actual usage of it. Thus, we aren't making any backwards-incompatible changes or affecting any downstream users with them here.

The final fix here is to use `.. disable_try_examples`, so that it is syntactically interpreted as a reST comment and thereby doesn't appear in the HTML documentation.

<hr>

~> [!IMPORTANT]~
> ~~**Update (also see my comment below):** fixing the documentation to match with the code, i.e., using and checking for `..! disable_try_examples::` results in problems from it being perceived by `docutils` as a directive, and causes warnings upon using it. I have thus decided to fix the code to match the existing documentation. Thus, the code now checks for just `..! disable_try_examples`, and not `..! disable_try_examples::`.~~

cc: @steppi 
