### PR TITLE
Gitignore `node_modules/`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ docs/build
 build
 dist
 .jupyterlite.doit.db
+node_modules/


### PR DESCRIPTION
Prettier apparently creates a cache in `./node_modules` when run through pre-commit:

```
node_modules/
└── .cache
    └── prettier
        └── .prettier-caches
            └── 20c1c711eb427ab66753c7c9b53f899d5073eb81.json
```

Not what I expected, but OK :) Let's avoid committing that.