### PR TITLE
Run `black` at pre-commit time

### DIFF
--- a/.github/workflows/check-release.yml
+++ b/.github/workflows/check-release.yml
@@ -5,8 +5,7 @@ on:
   pull_request:
 
 permissions:
-  contents:
-    write
+  contents: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,10 +3,10 @@ name: Tests
 on:
   push:
     branches:
-    - main
+      - main
   pull_request:
     branches:
-    - main
+      - main
 
 defaults:
   run:
@@ -20,20 +20,20 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.9']
+        python-version: ["3.9"]
 
     steps:
-    - name: Checkout
-      uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
 
-    - name: Setup conda
-      uses: conda-incubator/setup-miniconda@v3
-      with:
-        activate-environment: jupyterlite-sphinx
-        environment-file: dev-environment.yml
-        python-version: ${{ matrix.python-version }}
-        miniforge-version: latest
-        auto-activate-base: false
+      - name: Setup conda
+        uses: conda-incubator/setup-miniconda@v3
+        with:
+          activate-environment: jupyterlite-sphinx
+          environment-file: dev-environment.yml
+          python-version: ${{ matrix.python-version }}
+          miniforge-version: latest
+          auto-activate-base: false
 
-    - name: Test PEP8
-      run: black --check jupyterlite_sphinx
+      - name: Test PEP8
+        run: black --check jupyterlite_sphinx

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,17 +1,17 @@
 repos:
-- repo: https://github.com/pre-commit/mirrors-prettier
-  rev: 'v4.0.0-alpha.8'  # Use the sha / tag you want to point at
-  hooks:
-  - id: prettier
-    types_or: [css, javascript, yaml]
-- repo: https://github.com/astral-sh/ruff-pre-commit
-  # Ruff version.
-  rev: v0.12.9
-  hooks:
-    # Run the linter.
-    - id: ruff
-      args: [ --fix ]
-- repo: https://github.com/psf/black
-  rev: 25.1.0
-  hooks:
-    - id: black
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: "v4.0.0-alpha.8" # Use the sha / tag you want to point at
+    hooks:
+      - id: prettier
+        types_or: [css, javascript, yaml]
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    # Ruff version.
+    rev: v0.12.9
+    hooks:
+      # Run the linter.
+      - id: ruff
+        args: [--fix]
+  - repo: https://github.com/psf/black
+    rev: 25.1.0
+    hooks:
+      - id: black

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ repos:
   rev: 'v4.0.0-alpha.8'  # Use the sha / tag you want to point at
   hooks:
   - id: prettier
-    types_or: [css, javascript]
+    types_or: [css, javascript, yaml]
 - repo: https://github.com/astral-sh/ruff-pre-commit
   # Ruff version.
   rev: v0.12.9

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,4 +11,7 @@ repos:
     # Run the linter.
     - id: ruff
       args: [ --fix ]
-
+- repo: https://github.com/psf/black
+  rev: 25.1.0
+  hooks:
+    - id: black

--- a/dev-environment.yml
+++ b/dev-environment.yml
@@ -1,19 +1,19 @@
 name: jupyterlite-sphinx-dev
 channels:
-    - conda-forge
+  - conda-forge
 dependencies:
-    - pip
-    - jupyter_server
-    - jupyterlab_server
-    - jupyterlite-core >=0.3,<0.7
-    - jupytext
-    - pydata-sphinx-theme
-    - micromamba=2.0.5
-    - myst-parser
-    - docutils
-    - sphinx
-    - black
-    - voici
-    - pip:
-        - .
-        - jupyterlite-xeus >=2.1.2
+  - pip
+  - jupyter_server
+  - jupyterlab_server
+  - jupyterlite-core >=0.3,<0.7
+  - jupytext
+  - pydata-sphinx-theme
+  - micromamba=2.0.5
+  - myst-parser
+  - docutils
+  - sphinx
+  - black
+  - voici
+  - pip:
+      - .
+      - jupyterlite-xeus >=2.1.2


### PR DESCRIPTION
My PR #309 passed pre-commit checks, but failed when GitHub Actions ran `black --check`. Running `black` at pre-commit time is a bit less frictiony :)

I considered using Ruff for formatting, but Ruff and Black have, I believe, diverged slightly. I think switching CI + pre-commit to both use Ruff for formatting would be better done in a separate PR.