### PR TITLE
Bump jupyterlite-core dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     "docutils",
     "jupyter_server",
     "jupyterlab_server",
-    "jupyterlite-core >=0.2,<0.7",
+    "jupyterlite-core >=0.2,<0.8",
     "jupytext",
     "nbformat",
     "sphinx>=4",


### PR DESCRIPTION
Closes: https://github.com/jupyterlite/jupyterlite-sphinx/issues/315

Writing #315 I thought his would be a bigger deal, but seeing what was done in #299, a small bump may be all it needs. 0.7 works fine with me for building aiocoap documentation (modulo the trouble of actually getting the conflicting packages installed, which should be easier now that this branch can be used to install).