### PR TITLE
Reduce pre-commit autoupdate frequency to monthly

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,6 @@
+ci:
+  autoupdate_schedule: monthly
+
 repos:
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: "v4.0.0-alpha.8" # Use the sha / tag you want to point at


### PR DESCRIPTION
The default (weekly) is a lot of noise for maintainers! Let's reduce that by 4x? :) None of our hooks really justify a frequent update, IMO. We could even go quarterly. If there's a particular feature we're itching for, a manual PR is pretty low lift.