### PR TITLE
run `jupyter lite build` with `check=False`

### DIFF
--- a/jupyterlite_sphinx/jupyterlite_sphinx.py
+++ b/jupyterlite_sphinx/jupyterlite_sphinx.py
@@ -1102,7 +1102,7 @@ def jupyterlite_build(app: Sphinx, error):
 
         print(f"[jupyterlite-sphinx] Command: {command}")
         completed_process: CompletedProcess[bytes] = subprocess.run(
-            command, cwd=app.srcdir, check=True, **kwargs
+            command, cwd=app.srcdir, check=False, **kwargs
         )
 
         if completed_process.returncode != 0:

--- a/jupyterlite_sphinx/jupyterlite_sphinx.py
+++ b/jupyterlite_sphinx/jupyterlite_sphinx.py
@@ -1111,8 +1111,16 @@ def jupyterlite_build(app: Sphinx, error):
                     "[jupyterlite-sphinx] `jupyterlite build` failed but its"
                     " output has been silenced. stdout and stderr are reproduced below."
                 )
-                print(f"{'-' * 15} stdout {'-' * 15}", completed_process.stdout.decode(), sep="\n")
-                print(f"{'-' * 15} stderr {'-' * 15}", completed_process.stderr.decode(), sep="\n")
+                print(
+                    f"{'-' * 15} stdout {'-' * 15}",
+                    completed_process.stdout.decode(),
+                    sep="\n",
+                )
+                print(
+                    f"{'-' * 15} stderr {'-' * 15}",
+                    completed_process.stderr.decode(),
+                    sep="\n",
+                )
                 print(f"{'-' * 15} end output {'-' * 15}")
 
             # raise the original error without changing the traceback

--- a/jupyterlite_sphinx/jupyterlite_sphinx.py
+++ b/jupyterlite_sphinx/jupyterlite_sphinx.py
@@ -1101,11 +1101,11 @@ def jupyterlite_build(app: Sphinx, error):
             kwargs["stderr"] = subprocess.PIPE
 
         print(f"[jupyterlite-sphinx] Command: {command}")
-        completed_process: CompletedProcess[bytes] = subprocess.run(
-            command, cwd=app.srcdir, check=False, **kwargs
-        )
-
-        if completed_process.returncode != 0:
+        try:
+            completed_process: CompletedProcess[bytes] = subprocess.run(
+                command, cwd=app.srcdir, check=True, **kwargs
+            )
+        except subprocess.CalledProcessError:
             if app.env.config.jupyterlite_silence:
                 print(
                     "`jupyterlite build` failed but its output has been silenced."
@@ -1114,13 +1114,8 @@ def jupyterlite_build(app: Sphinx, error):
                 print("stdout:", completed_process.stdout.decode())
                 print("stderr:", completed_process.stderr.decode())
 
-            # Raise the original exception that would have occurred with check=True
-            raise subprocess.CalledProcessError(
-                returncode=completed_process.returncode,
-                cmd=command,
-                output=completed_process.stdout,
-                stderr=completed_process.stderr,
-            )
+            # raise the original error without changing the traceback
+            raise
 
         print("[jupyterlite-sphinx] JupyterLite build done")
 

--- a/jupyterlite_sphinx/jupyterlite_sphinx.py
+++ b/jupyterlite_sphinx/jupyterlite_sphinx.py
@@ -1108,11 +1108,12 @@ def jupyterlite_build(app: Sphinx, error):
         except subprocess.CalledProcessError:
             if app.env.config.jupyterlite_silence:
                 print(
-                    "`jupyterlite build` failed but its output has been silenced."
-                    " stdout and stderr are reproduced below.\n"
+                    "[jupyterlite-sphinx] `jupyterlite build` failed but its"
+                    " output has been silenced. stdout and stderr are reproduced below."
                 )
-                print("stdout:", completed_process.stdout.decode())
-                print("stderr:", completed_process.stderr.decode())
+                print(f"{'-' * 15} stdout {'-' * 15}", completed_process.stdout.decode(), sep="\n")
+                print(f"{'-' * 15} stderr {'-' * 15}", completed_process.stderr.decode(), sep="\n")
+                print(f"{'-' * 15} end output {'-' * 15}")
 
             # raise the original error without changing the traceback
             raise


### PR DESCRIPTION
From the code below, I believe the intention is to have `subprocess.run` _not_ raise on error, but instead print the output of the program and then raise another error.

This could also be refactored to something like:

``` python
try:
    completed_process = subprocess.run(..., check=True)
except subprocess.CalledProcessError:
    if app.env.config.jupyterlite_silence:
        print("[jupyterlite-sphinx] `jupyterlite build` failed ...")
        print(...)
    
    # reraise the exception
    raise
```
That way the code would be independent of eventual changes to `check`.

Also, it may be a good idea to add start / end markers to stdout / stderr, because that will almost certainly span multiple lines.

(To be clear, if any of these sound good to you I'll add them as new commits to this PR)