### PR TITLE
Fix overflow for JupyterLite iframes when added by directives used inside PST admonitions

### DIFF
--- a/jupyterlite_sphinx/jupyterlite_sphinx.css
+++ b/jupyterlite_sphinx/jupyterlite_sphinx.css
@@ -66,7 +66,7 @@
   background:
     radial-gradient(farthest-side, #ffa516 94%, #0000) top/8px 8px no-repeat,
     conic-gradient(#0000 30%, #ffa516);
-  -webkit-mask: radial-gradient(farthest-side, #0000 calc(100% - 8px), #000 0);
+  mask: radial-gradient(farthest-side, #0000 calc(100% - 8px), #000 0);
   animation: l13 1s infinite linear;
 }
 @keyframes l13 {

--- a/jupyterlite_sphinx/jupyterlite_sphinx.css
+++ b/jupyterlite_sphinx/jupyterlite_sphinx.css
@@ -1,3 +1,9 @@
+:root {
+  /* This variable mirrors the per-side margin the PyData Sphinx Theme applies to the
+     children of the admonitions. FIXME later; find a way to keep this stable */
+  --jls-admonition-indent: 1.4rem;
+}
+
 .jupyterlite_sphinx_raw_iframe {
   border-width: 1px;
   border-style: solid;
@@ -67,4 +73,34 @@
   100% {
     transform: rotate(1turn);
   }
+}
+
+/*
+ * A hack to fix the JupyterLite iframes overflowing admonitions in the PyData Sphinx Theme,
+ * (notwithstanding any contemporary themes we don't verify in our CI against).
+ *
+ * The pydata-sphinx-theme applies margins to every sibling of the admonition title:
+ * https://github.com/pydata/pydata-sphinx-theme/blob/213af5a59dd18500fdc3b82fb49afc89a54fff33/src/pydata_sphinx_theme/assets/styles/content/_admonitions.scss#L28-L32
+ *
+ *   .admonition p.admonition-title ~ *,
+ *   div.admonition p.admonition-title ~ * {
+ *     margin-left: 1.4rem;
+ *     margin-right: 1.4rem;
+ *   }
+ *
+ * Because the JupyterLite iframe container already carries a width="100%" (of the
+ * admonition's content box, that is), the extra 1.4rem on each side pushes the
+ * rendered width to 100% + 2.8rem and causes a visible overflow to the right. We
+ * tackle this below. */
+
+/* non-prompted case: the bare <iframe> emitted by _PromptedIframe.html() */
+.admonition p.admonition-title ~ iframe.jupyterlite_sphinx_raw_iframe,
+div.admonition p.admonition-title ~ iframe.jupyterlite_sphinx_raw_iframe {
+  width: calc(100% - 2 * var(--jls-admonition-indent));
+}
+
+/* prompted case: <div class="jupyterlite_sphinx_iframe_container"> */
+.admonition p.admonition-title ~ div.jupyterlite_sphinx_iframe_container,
+div.admonition p.admonition-title ~ div.jupyterlite_sphinx_iframe_container {
+  width: calc(100% - 2 * var(--jls-admonition-indent));
 }


### PR DESCRIPTION
This PR fixes the visual bug I identified in point 1 of https://github.com/jupyterlite/jupyterlite-sphinx/pull/290#issuecomment-3955068843 about the JupyterLite REPL (and other apps') iframes overflowing if they are part of admonitions. This is a hack right now and may or may not work with other themes, but we've never marketed official support of the extension for themes beyond the PST anyway.

Since #290 is not merged yet, I applied these changes on top of it locally, and the following screenshots showcase the difference/fix (please ignore the non-working iframe in the "After" image, that's not related):

| Before ( | After |
|--------|--------|
| <img width="723" height="834" alt="image" src="https://github.com/user-attachments/assets/6254429b-aec4-49ca-9f04-8d2f1f12e0cc" /> | <img width="723" height="834" alt="image" src="https://github.com/user-attachments/assets/a35f08b1-6632-44e2-a3be-4d6af4b71ef0" /> | 

<hr>

also cc: @Carreau for visibility; as this involves the PST