### PR TITLE
Drop support for Python 3.9

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.9"]
+        python-version: ["3.10"]
 
     steps:
       - name: Checkout

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 description = "Sphinx extension for deploying JupyterLite"
 readme = "README.md"
 license = { file = "LICENSE" }
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 authors = [
     { name = "JupyterLite Contributors" },
 ]


### PR DESCRIPTION
As @keewis pointed out to me in #332, Python 3.9 is now EOL. It reached this status on 31 October, 2025, as mentioned on https://endoflife.date/python.