### PR TITLE
Use dependency groups instead of optional dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,11 +22,10 @@ dependencies = [
     "sphinx>=4",
 ]
 
-[project.optional-dependencies]
+[dependency-groups]
 dev = [
     "hatch",
 ]
-
 docs = [
     "myst_parser",
     "pydata-sphinx-theme",


### PR DESCRIPTION
These were never meant to be listed in public metadata anyway, so we can avoid doing that now :D This is also in prep for #329.

No other changes should be needed – I checked `.readthedocs.yaml` (https://docs.readthedocs.com/platform/latest/build-customization.html#install-dependencies-from-dependency-groups) but this doesn't apply to us as we list all our docs build dependencies directly in the requirements there. I don't see any other places where we mention `[docs]`, `[dev]`, `[dev,docs]`, etc. either.