### PR TITLE
Experimental accordion-style sliding for `TryExamples` iframe panels, as a means to avoid content layout shift

### DIFF
--- a/docs/_static/try_examples.css
+++ b/docs/_static/try_examples.css
@@ -27,8 +27,7 @@
   justify-content: flex-end;
 }
 
-.try_examples_outer_container,
-.try_examples_outer_iframe {
+.try_examples_outer_container {
   flex-direction: column-reverse;
   display: flex;
 }
@@ -37,8 +36,7 @@
  * set the display mode would lead to the iframe/container always visible.
  * */
 
-.try_examples_outer_container.hidden,
-.try_examples_outer_iframe.hidden {
+.try_examples_outer_container.hidden {
   display: none;
 }
 

--- a/jupyterlite_sphinx/jupyterlite_sphinx.css
+++ b/jupyterlite_sphinx/jupyterlite_sphinx.css
@@ -58,9 +58,23 @@ when the buttons are clicked. */
   margin-top: 0.75rem;
 }
 
+.try_examples_chevron {
+  display: inline-block;
+  transition: transform var(--open-duration, 0.2s) ease-in-out;
+  margin-left: 0.3em;
+}
+
+.try_examples_button[aria-expanded="true"] .try_examples_chevron {
+  transform: rotate(90deg);
+}
+
 @media (prefers-reduced-motion: reduce) {
   .try_examples_outer_iframe {
     --open-duration: 0s;
+  }
+
+  .try_examples_chevron {
+    transition: none;
   }
 
   .jupyterlite_sphinx_spinner {

--- a/jupyterlite_sphinx/jupyterlite_sphinx.css
+++ b/jupyterlite_sphinx/jupyterlite_sphinx.css
@@ -62,6 +62,7 @@ when the buttons are clicked. */
   display: inline-block;
   transition: transform var(--open-duration, 0.2s) ease-in-out;
   margin-left: 0.3em;
+  font-size: 0.75em;
 }
 
 .try_examples_button[aria-expanded="true"] .try_examples_chevron {

--- a/jupyterlite_sphinx/jupyterlite_sphinx.css
+++ b/jupyterlite_sphinx/jupyterlite_sphinx.css
@@ -55,6 +55,7 @@ when the buttons are clicked. */
   max-height: 0;
   overflow: hidden;
   transition: max-height var(--open-duration) ease-in-out;
+  margin-top: 0.75rem;
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/jupyterlite_sphinx/jupyterlite_sphinx.css
+++ b/jupyterlite_sphinx/jupyterlite_sphinx.css
@@ -48,6 +48,25 @@
   display: none;
 }
 
+/* The iframe panel is collapsed by default and expands
+when the buttons are clicked. */
+.try_examples_outer_iframe {
+  --open-duration: 0.2s;
+  max-height: 0;
+  overflow: hidden;
+  transition: max-height var(--open-duration) ease-in-out;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .try_examples_outer_iframe {
+    --open-duration: 0s;
+  }
+
+  .jupyterlite_sphinx_spinner {
+    animation: none;
+  }
+}
+
 .jupyterlite_sphinx_spinner {
   /* From https://css-loaders.com/spinner/ */
   position: absolute;

--- a/jupyterlite_sphinx/jupyterlite_sphinx.js
+++ b/jupyterlite_sphinx/jupyterlite_sphinx.js
@@ -65,8 +65,7 @@ window.tryExamplesShowIframe = (
   );
   const iframeContainer = document.getElementById(iframeContainerId);
 
-  // Find the toggle button to update its text to "Hide"
-  // when the iframe is shown, and to reset it when hidden
+  // Find the toggle button to update aria-expanded state
   const toggleButton = examplesContainer.querySelector(".try_examples_button");
 
   const isOpen = iframeParentContainer.classList.contains(
@@ -82,9 +81,6 @@ window.tryExamplesShowIframe = (
     iframeParentContainer.classList.remove("try_examples_iframe_open");
     if (toggleButton) {
       toggleButton.setAttribute("aria-expanded", "false");
-      if (toggleButton.dataset.originalText) {
-        toggleButton.textContent = toggleButton.dataset.originalText;
-      }
     }
     return;
   }
@@ -92,10 +88,6 @@ window.tryExamplesShowIframe = (
   // To expand the iframe panel
   if (toggleButton) {
     toggleButton.setAttribute("aria-expanded", "true");
-    if (!toggleButton.dataset.originalText) {
-      toggleButton.dataset.originalText = toggleButton.textContent;
-    }
-    toggleButton.textContent = "Hide";
   }
   iframeParentContainer.classList.add("try_examples_iframe_open");
 

--- a/jupyterlite_sphinx/jupyterlite_sphinx.py
+++ b/jupyterlite_sphinx/jupyterlite_sphinx.py
@@ -864,25 +864,10 @@ class TryExamplesDirective(SphinxDirective):
         iframe_div_id = uuid4()
         iframe_src = f'{prefix}/{app_path}{f"index.html?{options}" if options else ""}'
 
-        # Parent container (initially hidden)
-        iframe_parent_container_div_start = (
-            f'<div id="{iframe_parent_div_id}" '
-            f'class="try_examples_outer_iframe {example_class} hidden">'
-        )
-
-        iframe_parent_container_div_end = "</div>"
         iframe_container_div = (
             f'<div id="{iframe_div_id}" '
             f'class="jupyterlite_sphinx_iframe_container">'
             f"</div>"
-        )
-
-        # Button with the onclick event to swap embedded notebook back to examples.
-        go_back_button_html = (
-            '<button class="try_examples_button" '
-            f"onclick=\"window.tryExamplesHideIframe('{examples_div_id}',"
-            f"'{iframe_parent_div_id}')\">"
-            "Go Back</button>"
         )
 
         full_screen_button_html = (
@@ -892,32 +877,31 @@ class TryExamplesDirective(SphinxDirective):
             "Open In Tab</button>"
         )
 
-        # Button with the onclick event to swap examples with embedded notebook.
+        # Button that toggles the iframe panel open/close.
         try_it_button_html = (
             '<div class="try_examples_button_container">'
             '<button class="try_examples_button" '
+            f'aria-expanded="false" '
+            f'aria-controls="{iframe_parent_div_id}" '
             f"onclick=\"window.tryExamplesShowIframe('{examples_div_id}',"
             f"'{iframe_div_id}','{iframe_parent_div_id}','{iframe_src}',"
             f"'{height}')\">"
-            f"{button_text}</button>"
-            "</div>"
+            f"{button_text}</button>" + full_screen_button_html + "</div>"
         )
         try_it_button_node = nodes.raw("", try_it_button_html, format="html")
 
         # Combine everything
-        notebook_container_html = (
-            iframe_parent_container_div_start
-            + '<div class="try_examples_button_container">'
-            + go_back_button_html
-            + full_screen_button_html
-            + "</div>"
+        iframe_panel_html = (
+            f'<div id="{iframe_parent_div_id}" '
+            f'class="try_examples_outer_iframe {example_class}">'
             + iframe_container_div
-            + iframe_parent_container_div_end
+            + "</div>"
         )
+
         content_container_node += try_it_button_node
         content_container_node += content_node
 
-        notebook_container = nodes.raw("", notebook_container_html, format="html")
+        iframe_panel_node = nodes.raw("", iframe_panel_html, format="html")
 
         # Search config file allowing for config changes without rebuilding docs.
         config_path = os.path.join(relative_path_to_root, "try_examples.json")
@@ -930,7 +914,7 @@ class TryExamplesDirective(SphinxDirective):
         )
         script_node = nodes.raw("", script_html, format="html")
 
-        return [content_container_node, notebook_container, script_node]
+        return [content_container_node, iframe_panel_node, script_node]
 
 
 def _process_docstring_examples(app: Sphinx, docname: str, source: List[str]) -> None:

--- a/jupyterlite_sphinx/jupyterlite_sphinx.py
+++ b/jupyterlite_sphinx/jupyterlite_sphinx.py
@@ -886,7 +886,11 @@ class TryExamplesDirective(SphinxDirective):
             f"onclick=\"window.tryExamplesShowIframe('{examples_div_id}',"
             f"'{iframe_div_id}','{iframe_parent_div_id}','{iframe_src}',"
             f"'{height}')\">"
-            f"{button_text}</button>" + full_screen_button_html + "</div>"
+            # TODO: what do we do if FontAwesome is not available? Find a unicode
+            # charactive alternative. PST includes FA so it should be fine, but
+            # we don't want to break if someone is not using PST.
+            f'{button_text} <i class="fa-solid fa-chevron-right try_examples_chevron"'
+            f' aria-hidden="true"></i></button>' + full_screen_button_html + "</div>"
         )
         try_it_button_node = nodes.raw("", try_it_button_html, format="html")
 


### PR DESCRIPTION
> [!IMPORTANT]
> This is an experimental PR to gather feedback at this time. It is ready for review, but is not yet intended to be merged. 

This PR introduces a refactor of the interactive example panel for accessibility reasons, i.e., to avoid content layout shifts that arise when a TryExamples directive button is clicked to replace the examples code snippet section with the JupyterLite iframe. With these changes, I would like to showcase an alternative approach. Instead of hiding/replacing the examples section, we keep it and expand the JupyterLite iframe, which slides down when the "Try it!" button is clicked. This means that while there is some duplication of examples, our accessibility improves overall, and we also have a nice iframe that slides down and slides back up. When the iframe is open, the "Try it!" button logically changes to a "Hide" button. IMO, the user's context is preserved: they can see the original example code snippets while interacting with the notebook, and they don't lose their place on the page because the page's elements don't jump around.

There are a couple of associated accessibility-related changes here, such as disabling animations when reduced motion is preferred and adding more ARIA attributes to indicate the iframe's expansion/contraction. I got them from reading this blog post: https://dev.to/grahamthedev/accessible-animated-accordion-in-pure-css-no-way-5980. We can bring the latter in its own separate PR if we decide not to go ahead with this approach.