### PR TITLE
Unpin `jupyterlite-xeus` in docs dependency group and use latest micromamba for docs builds

### DIFF
--- a/dev-environment.yml
+++ b/dev-environment.yml
@@ -8,7 +8,7 @@ dependencies:
   - jupyterlite-core >=0.3,<0.7
   - jupytext
   - pydata-sphinx-theme
-  - micromamba=2.0.5
+  - micromamba
   - myst-parser
   - docutils
   - sphinx

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dev = [
 docs = [
     "myst_parser",
     "pydata-sphinx-theme",
-    "jupyterlite-xeus>=0.1.8,<4",
+    "jupyterlite-xeus>=0.1.8",
 ]
 
 [tool.hatch.version]


### PR DESCRIPTION
Trying out https://github.com/jupyterlite/xeus/pull/199 here to see if we can unpin these dependencies now. Note that jupyterlite-xeus was not pinned in RTD as we don't use dependency groups, the pin just affected developers like me who use `uv`/`pip` to manage their environments. micromamba was pinned in #277 has been reverted now.