### PR TITLE
allow configuring the path of the contents directory

### DIFF
--- a/jupyterlite_sphinx/jupyterlite_sphinx.py
+++ b/jupyterlite_sphinx/jupyterlite_sphinx.py
@@ -961,8 +961,13 @@ def conditional_process_examples(app, config):
 
 
 def inited(app: Sphinx, config):
+    if not app.config.jupyterlite_content_dir:
+        raise ValueError("jupyterlite_content_dir must be a non-zero string")
+    content_dir = Path(app.srcdir) / app.config.jupyterlite_content_dir
+    shutil.rmtree(content_dir, ignore_errors=True)
+        
     # Create the content dir
-    os.makedirs(os.path.join(app.srcdir, CONTENT_DIR), exist_ok=True)
+    content_dir.mkdir(exist_ok=True, parents=True)
 
     if (
         config.jupyterlite_bind_ipynb_suffix
@@ -1076,7 +1081,7 @@ def jupyterlite_build(app: Sphinx, error):
             *overrides,
             *contents,
             "--contents",
-            os.path.join(app.srcdir, CONTENT_DIR),
+            os.path.join(app.srcdir, app.env.config.jupyterlite_content_dir),
             *ignore_contents,
             "--output-dir",
             os.path.join(app.outdir, JUPYTERLITE_DIR),
@@ -1140,7 +1145,6 @@ def jupyterlite_build(app: Sphinx, error):
 
     # Cleanup
     try:
-        shutil.rmtree(os.path.join(app.srcdir, CONTENT_DIR))
         os.remove(".jupyterlite.doit.db")
     except FileNotFoundError:
         pass

--- a/jupyterlite_sphinx/jupyterlite_sphinx.py
+++ b/jupyterlite_sphinx/jupyterlite_sphinx.py
@@ -611,7 +611,9 @@ class _LiteDirective(SphinxDirective):
 
             self.env.jupyterlite_notebooks.add(str(notebook_path))
 
-            notebooks_dir = Path(self.env.app.srcdir) / self.env.config.jupyterlite_content_dir
+            notebooks_dir = (
+                Path(self.env.app.srcdir) / self.env.config.jupyterlite_content_dir
+            )
 
             os.makedirs(notebooks_dir, exist_ok=True)
 
@@ -844,7 +846,9 @@ class TryExamplesDirective(SphinxDirective):
                 nb.cells.insert(1, new_code_cell(preamble))
 
             self.content = None
-            notebooks_dir = Path(self.env.app.srcdir) / self.env.config.jupyterlite_content_dir
+            notebooks_dir = (
+                Path(self.env.app.srcdir) / self.env.config.jupyterlite_content_dir
+            )
             notebook_unique_name = f"{uuid4()}.ipynb".replace("-", "_")
             self.env.temp_data["generated_notebooks"][
                 directive_key
@@ -965,7 +969,7 @@ def inited(app: Sphinx, config):
         raise ValueError("jupyterlite_content_dir must be a non-zero string")
     content_dir = Path(app.srcdir) / app.config.jupyterlite_content_dir
     shutil.rmtree(content_dir, ignore_errors=True)
-        
+
     # Create the content dir
     content_dir.mkdir(exist_ok=True, parents=True)
 

--- a/jupyterlite_sphinx/jupyterlite_sphinx.py
+++ b/jupyterlite_sphinx/jupyterlite_sphinx.py
@@ -611,7 +611,8 @@ class _LiteDirective(SphinxDirective):
 
             self.env.jupyterlite_notebooks.add(str(notebook_path))
 
-            notebooks_dir = Path(self.env.app.srcdir) / CONTENT_DIR
+            notebooks_dir = Path(self.env.app.srcdir) / self.env.config.jupyterlite_content_dir
+
             os.makedirs(notebooks_dir, exist_ok=True)
 
             self._assert_no_conflicting_nb_names(notebook_path, notebooks_dir)
@@ -843,7 +844,7 @@ class TryExamplesDirective(SphinxDirective):
                 nb.cells.insert(1, new_code_cell(preamble))
 
             self.content = None
-            notebooks_dir = Path(self.env.app.srcdir) / CONTENT_DIR
+            notebooks_dir = Path(self.env.app.srcdir) / self.env.config.jupyterlite_content_dir
             notebook_unique_name = f"{uuid4()}.ipynb".replace("-", "_")
             self.env.temp_data["generated_notebooks"][
                 directive_key
@@ -1175,6 +1176,7 @@ def setup(app):
         rebuild="html",
     )
     app.add_config_value("try_examples_preamble", default=None, rebuild="html")
+    app.add_config_value("jupyterlite_content_dir", default=CONTENT_DIR, rebuild="html")
 
     # Allow customising the button text for each directive (this is useful
     # only when "new_tab" is set to True)


### PR DESCRIPTION
This is the one remaining issue I have before being able to merge the PR that adds `try_examples` to the `xarray` docs.

Basically, I would run sphinx once and then retry again after making changes, and if the first run exited with a non-zero exit code the second run would try to execute all the notebooks in the `_contents` directory. However, if I were to add `_contents` to `exclude_patterns` `jupyterlite` wouldn't be able to find the notebooks in `_contents`.

As far as I can tell, changing the path from `_contents` to `_build/contents` (or `_build/jupyterlite-contents`) would always succeed, and wouldn't get confused by `exclude_patterns`. So what I did was:
1. make the path configurable
2. clean up _before the next run_ instead of _after the current run_

cc @agriyakhetarpal