### PR TITLE
Update to latest emscripten-forge

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -49,8 +49,8 @@ Say you want to install NumPy, Matplotlib and ipycanvas, it can be done by creat
 ```yaml
 name: xeus-python-kernel
 channels:
-  - https://repo.mamba.pm/emscripten-forge
-  - https://repo.mamba.pm/conda-forge
+  - https://prefix.dev/emscripten-forge-4x
+  - https://prefix.dev/conda-forge
 dependencies:
   - numpy
   - matplotlib

--- a/docs/directives/replite.md
+++ b/docs/directives/replite.md
@@ -174,7 +174,7 @@ global value using an additional `:new_tab_button_text:` parameter:
 
    ```rst
    .. replite::
-      :kernel: xeus-python
+      :kernel: xpython
       :height: 600px
       :clear_cells_on_execute: True
 
@@ -185,7 +185,7 @@ global value using an additional `:new_tab_button_text:` parameter:
 
    ```{eval-rst}
    .. replite::
-      :kernel: xeus-python
+      :kernel: xpython
       :height: 600px
       :clear_cells_on_execute: True
 
@@ -200,7 +200,7 @@ global value using an additional `:new_tab_button_text:` parameter:
 
    ```rst
    .. replite::
-      :kernel: xeus-python
+      :kernel: xpython
       :height: 600px
       :clear_code_content_on_execute: True
 
@@ -211,7 +211,7 @@ global value using an additional `:new_tab_button_text:` parameter:
 
    ```{eval-rst}
    .. replite::
-      :kernel: xeus-python
+      :kernel: xpython
       :height: 600px
       :clear_code_content_on_execute: True
 
@@ -226,7 +226,7 @@ global value using an additional `:new_tab_button_text:` parameter:
 
    ```rst
    .. replite::
-      :kernel: xeus-python
+      :kernel: xpython
       :height: 600px
       :hide_code_input: True
 
@@ -237,7 +237,7 @@ global value using an additional `:new_tab_button_text:` parameter:
 
    ```{eval-rst}
    .. replite::
-      :kernel: xeus-python
+      :kernel: xpython
       :height: 600px
       :hide_code_input: True
 
@@ -252,7 +252,7 @@ global value using an additional `:new_tab_button_text:` parameter:
 
    ```rst
    .. replite::
-      :kernel: xeus-python
+      :kernel: xpython
       :height: 600px
       :prompt_cell_position: top
 
@@ -262,7 +262,7 @@ global value using an additional `:new_tab_button_text:` parameter:
 
    ```{eval-rst}
    .. replite::
-      :kernel: xeus-python
+      :kernel: xpython
       :height: 600px
       :prompt_cell_position: top
 
@@ -276,7 +276,7 @@ global value using an additional `:new_tab_button_text:` parameter:
 
    ```rst
    .. replite::
-      :kernel: xeus-python
+      :kernel: xpython
       :height: 600px
       :show_banner: False
 
@@ -286,7 +286,7 @@ global value using an additional `:new_tab_button_text:` parameter:
 
    ```{eval-rst}
    .. replite::
-      :kernel: xeus-python
+      :kernel: xpython
       :height: 600px
       :show_banner: False
 
@@ -301,7 +301,7 @@ global value using an additional `:new_tab_button_text:` parameter:
 
    ```rst
    .. replite::
-      :kernel: xeus-python
+      :kernel: xpython
       :prompt_cell_position: left
       :hide_code_input: True
       :show_banner: False
@@ -322,7 +322,7 @@ global value using an additional `:new_tab_button_text:` parameter:
 
    ```{eval-rst}
    .. replite::
-      :kernel: xeus-python
+      :kernel: xpython
       :prompt_cell_position: left
       :hide_code_input: True
       :show_banner: False

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -1,7 +1,7 @@
 name: jupyterlite-sphinx
 channels:
-  - https://repo.mamba.pm/emscripten-forge
-  - conda-forge
+  - https://prefix.dev/emscripten-forge-4x
+  - https://prefix.dev/conda-forge
 dependencies:
   - pandas
   - matplotlib

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,7 +6,7 @@ A Sphinx extension that provides utilities for embedding JupyterLite in your doc
 
 ```{eval-rst}
 .. replite::
-   :kernel: xeus-python
+   :kernel: xpython
    :toolbar: 0
    :theme: JupyterLab Light
    :width: 100%


### PR DESCRIPTION
Use latest emscripten-forge in docs:
- Switch from Python 3.11 to Python 3.13
- Get latest packages versions
- Use the prefix.dev channel instead of the legacy one